### PR TITLE
feat: Implement About page redesign

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,3 +8,12 @@ export const onServiceWorkerUpdateReady = () => {
     window.location.reload()
   }
 }
+
+// Add Google Fonts for About page redesign
+export const onClientEntry = () => {
+  // Create link element for Google Fonts
+  const link = document.createElement('link')
+  link.href = 'https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Noto+Sans+JP:wght@300;400;500;600&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,400&display=swap'
+  link.rel = 'stylesheet'
+  document.head.appendChild(link)
+}

--- a/src/assets/scss/about.scss
+++ b/src/assets/scss/about.scss
@@ -1,0 +1,549 @@
+// About Page Redesign Styles
+
+:root {
+  --color-bg: #FEFDFB;
+  --color-bg-alt: #F8F6F3;
+  --color-text: #1A1A1A;
+  --color-text-muted: #6B6B6B;
+  --color-accent: #C4583A;
+  --color-accent-light: #E8D5CF;
+  --color-border: #E5E2DE;
+  --font-display: 'Instrument Serif', serif;
+  --font-body: 'DM Sans', 'Noto Sans JP', sans-serif;
+  --font-jp: 'Noto Sans JP', sans-serif;
+  --spacing-xs: 0.5rem;
+  --spacing-sm: 1rem;
+  --spacing-md: 2rem;
+  --spacing-lg: 4rem;
+  --spacing-xl: 8rem;
+  --max-width: 1200px;
+  --transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+// Animations
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes scroll {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+// Language Toggle Styles
+[data-lang="en"] { display: none; }
+[data-lang="ja"] { display: block; }
+body.lang-en [data-lang="en"] { display: block; }
+body.lang-en [data-lang="ja"] { display: none; }
+
+.bilingual .en { display: none; }
+body.lang-en .bilingual .ja { display: none; }
+body.lang-en .bilingual .en { display: inline; }
+
+// Base About Page Styles
+.about-page-redesign {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  line-height: 1.7;
+
+  * {
+    box-sizing: border-box;
+  }
+
+  a {
+    color: var(--color-accent);
+    text-decoration: none;
+    transition: var(--transition);
+
+    &:hover {
+      color: darken(#C4583A, 10%);
+    }
+  }
+
+  h2 {
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 5vw, 3rem);
+    margin-bottom: var(--spacing-md);
+    color: var(--color-text);
+  }
+
+  .animate-in {
+    animation: fadeInUp 0.6s ease-out forwards;
+  }
+}
+
+// Language Toggle Component
+.lang-toggle {
+  display: flex;
+  gap: var(--spacing-xs);
+  justify-content: flex-end;
+  margin-bottom: var(--spacing-md);
+  padding: var(--spacing-sm) 0;
+
+  .lang-btn {
+    padding: 0.5rem 1.25rem;
+    border: 2px solid var(--color-border);
+    background: white;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    font-weight: 500;
+    font-family: var(--font-body);
+    cursor: pointer;
+    border-radius: 24px;
+    transition: var(--transition);
+
+    &:hover {
+      border-color: var(--color-accent);
+    }
+
+    &.active {
+      background: var(--color-accent);
+      color: white;
+      border-color: var(--color-accent);
+    }
+  }
+}
+
+// Hero Section
+.about-hero {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-lg);
+  align-items: center;
+  padding: var(--spacing-xl) 0;
+  max-width: var(--max-width);
+  margin: 0 auto;
+
+  .hero-content {
+    h1 {
+      font-family: var(--font-display);
+      font-size: clamp(2.5rem, 6vw, 4rem);
+      line-height: 1.2;
+      margin: 0 0 var(--spacing-sm);
+      color: var(--color-text);
+    }
+
+    .subtitle {
+      font-family: var(--font-jp);
+      font-size: clamp(1rem, 2vw, 1.25rem);
+      color: var(--color-text-muted);
+      margin-bottom: var(--spacing-md);
+      font-weight: 400;
+    }
+
+    .intro {
+      font-size: 1.125rem;
+      line-height: 1.8;
+      color: var(--color-text);
+      margin-bottom: var(--spacing-sm);
+    }
+  }
+
+  .hero-image {
+    position: relative;
+
+    img {
+      width: 100%;
+      max-width: 400px;
+      border-radius: 12px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+      display: block;
+      margin: 0 auto;
+    }
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: -20px;
+      left: -20px;
+      right: 20px;
+      bottom: 20px;
+      border: 2px solid var(--color-accent-light);
+      border-radius: 12px;
+      z-index: -1;
+    }
+  }
+}
+
+// Highlights Banner
+.highlights-banner {
+  background: var(--color-bg-alt);
+  padding: var(--spacing-md) 0;
+  overflow: hidden;
+  margin: var(--spacing-lg) 0;
+
+  .highlights-track {
+    display: flex;
+    gap: var(--spacing-md);
+    animation: scroll 30s linear infinite;
+
+    &:hover {
+      animation-play-state: paused;
+    }
+  }
+
+  .highlight-item {
+    flex-shrink: 0;
+    padding: var(--spacing-sm) var(--spacing-md);
+    background: white;
+    border-radius: 24px;
+    font-weight: 500;
+    font-size: 0.95rem;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  }
+}
+
+// Section Container
+.about-section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: var(--spacing-lg) var(--spacing-md);
+
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--spacing-md);
+  }
+}
+
+// Card Grid (Awards, Events, Podcasts)
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: var(--spacing-md);
+
+  .card {
+    padding: var(--spacing-md);
+    background: white;
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    transition: var(--transition);
+
+    &:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);
+    }
+
+    .card-year {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      background: var(--color-accent-light);
+      color: var(--color-accent);
+      border-radius: 16px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      margin-bottom: var(--spacing-sm);
+    }
+
+    .card-title {
+      font-size: 1.125rem;
+      font-weight: 600;
+      line-height: 1.5;
+      margin-bottom: var(--spacing-xs);
+      color: var(--color-text);
+    }
+
+    .card-org {
+      color: var(--color-text-muted);
+      font-size: 0.95rem;
+    }
+
+    &.featured {
+      border-color: var(--color-accent);
+      background: linear-gradient(135deg, #fff 0%, var(--color-bg-alt) 100%);
+
+      .featured-badge {
+        display: inline-block;
+        padding: 0.25rem 0.75rem;
+        background: var(--color-accent);
+        color: white;
+        border-radius: 16px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        margin-bottom: var(--spacing-sm);
+      }
+    }
+  }
+}
+
+// Timeline Section (Speaking)
+.timeline-section {
+  .filter-tabs {
+    display: flex;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-md);
+    flex-wrap: wrap;
+
+    button {
+      padding: 0.5rem 1.25rem;
+      border: 2px solid var(--color-border);
+      background: white;
+      color: var(--color-text-muted);
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      border-radius: 24px;
+      transition: var(--transition);
+
+      &:hover {
+        border-color: var(--color-accent);
+      }
+
+      &.active {
+        background: var(--color-accent);
+        color: white;
+        border-color: var(--color-accent);
+      }
+    }
+  }
+
+  .timeline {
+    position: relative;
+    padding-left: var(--spacing-lg);
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: var(--color-border);
+    }
+
+    .timeline-item {
+      display: grid;
+      grid-template-columns: 100px 1fr;
+      gap: var(--spacing-md);
+      margin-bottom: var(--spacing-md);
+      position: relative;
+
+      &::before {
+        content: '';
+        position: absolute;
+        left: -43px;
+        top: 8px;
+        width: 12px;
+        height: 12px;
+        background: var(--color-accent);
+        border-radius: 50%;
+        border: 3px solid var(--color-bg);
+      }
+
+      .timeline-date {
+        font-weight: 600;
+        color: var(--color-text-muted);
+        font-size: 0.95rem;
+      }
+
+      .timeline-content {
+        .timeline-title {
+          font-weight: 600;
+          font-size: 1.05rem;
+          line-height: 1.5;
+          margin-bottom: var(--spacing-xs);
+          color: var(--color-text);
+        }
+
+        .timeline-venue {
+          color: var(--color-text-muted);
+          font-size: 0.9rem;
+        }
+
+        .timeline-role {
+          display: inline-block;
+          margin-top: var(--spacing-xs);
+          padding: 0.25rem 0.75rem;
+          background: var(--color-bg-alt);
+          border-radius: 16px;
+          font-size: 0.8rem;
+          color: var(--color-text-muted);
+        }
+      }
+
+      &.hidden {
+        display: none;
+      }
+    }
+  }
+
+  .show-more-btn {
+    display: block;
+    margin: var(--spacing-md) auto 0;
+    padding: 0.75rem 2rem;
+    background: white;
+    border: 2px solid var(--color-accent);
+    color: var(--color-accent);
+    font-weight: 600;
+    border-radius: 24px;
+    cursor: pointer;
+    transition: var(--transition);
+
+    &:hover {
+      background: var(--color-accent);
+      color: white;
+    }
+  }
+}
+
+// Compact List (Research, Writing, Media)
+.compact-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--spacing-md);
+
+  .list-item {
+    display: flex;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-md);
+    background: white;
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    transition: var(--transition);
+
+    &:hover {
+      border-color: var(--color-accent);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    }
+
+    .item-icon {
+      font-size: 1.5rem;
+      flex-shrink: 0;
+    }
+
+    .item-content {
+      flex: 1;
+
+      .item-title {
+        font-weight: 600;
+        font-size: 0.95rem;
+        line-height: 1.5;
+        margin-bottom: var(--spacing-xs);
+        color: var(--color-text);
+      }
+
+      .item-meta {
+        color: var(--color-text-muted);
+        font-size: 0.85rem;
+      }
+    }
+  }
+}
+
+// Links Section (Footer)
+.links-section {
+  background: var(--color-text);
+  padding: var(--spacing-xl) var(--spacing-md);
+  margin-top: var(--spacing-xl);
+
+  h2 {
+    color: white;
+    text-align: center;
+    margin-bottom: var(--spacing-lg);
+  }
+
+  .links-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: var(--spacing-md);
+    max-width: var(--max-width);
+    margin: 0 auto;
+
+    .link-card {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+      padding: var(--spacing-md);
+      background: rgba(255, 255, 255, 0.1);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 12px;
+      color: white;
+      transition: var(--transition);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.15);
+        border-color: rgba(255, 255, 255, 0.4);
+        transform: translateY(-2px);
+      }
+
+      .link-icon {
+        width: 32px;
+        height: 32px;
+        flex-shrink: 0;
+      }
+
+      .link-name {
+        font-weight: 600;
+        font-size: 1rem;
+      }
+    }
+  }
+}
+
+// Responsive Design
+@media (max-width: 768px) {
+  .about-hero {
+    grid-template-columns: 1fr;
+    padding: var(--spacing-md) 0;
+    text-align: center;
+
+    .hero-image {
+      order: -1;
+
+      img {
+        max-width: 300px;
+      }
+    }
+  }
+
+  .timeline-section {
+    .timeline {
+      padding-left: var(--spacing-md);
+
+      .timeline-item {
+        grid-template-columns: 1fr;
+        gap: var(--spacing-xs);
+
+        &::before {
+          left: -27px;
+        }
+
+        .timeline-date {
+          display: inline-block;
+          padding: 0.25rem 0.75rem;
+          background: var(--color-bg-alt);
+          border-radius: 16px;
+          font-size: 0.8rem;
+          width: fit-content;
+        }
+      }
+    }
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .compact-list {
+    grid-template-columns: 1fr;
+  }
+
+  .links-section .links-grid {
+    grid-template-columns: 1fr;
+  }
+
+  :root {
+    --spacing-lg: 2rem;
+    --spacing-xl: 4rem;
+  }
+}

--- a/src/components/AboutHero.jsx
+++ b/src/components/AboutHero.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+const AboutHero = () => {
+  return (
+    <div className="about-hero animate-in">
+      <div className="hero-content">
+        <h1>
+          <span data-lang="ja">神谷 優</span>
+          <span data-lang="en">Yu Kamiya</span>
+        </h1>
+        <p className="subtitle">
+          <span data-lang="ja">ソフトウェアエンジニア / Tech DE&I リード</span>
+          <span data-lang="en">Software Engineer / Tech DE&I Lead</span>
+        </p>
+        <p className="intro" data-lang="ja">
+          サイバーエージェントにてソフトウェアエンジニアとして、子ども向けプログラミング学習サービス「QUREO」の開発に携わる傍ら、IT業界のジェンダーギャップ解消を目指す「Tech DE&Iプロジェクト」をリードしています。
+        </p>
+        <p className="intro" data-lang="en">
+          At CyberAgent, I work as a software engineer developing "QUREO," a programming education service for children, while leading the "Tech DE&I Project" aimed at eliminating gender gaps in the IT industry.
+        </p>
+      </div>
+      <div className="hero-image">
+        <img src="/assets/site_profile_1.jpg" alt="Yu Kamiya" />
+      </div>
+    </div>
+  )
+}
+
+export default AboutHero

--- a/src/components/CardGrid.jsx
+++ b/src/components/CardGrid.jsx
@@ -1,30 +1,45 @@
 import React from 'react'
 
-const CardGrid = ({ items, featured = false }) => {
+const CardGrid = ({ items }) => {
+  const CardContent = ({ item }) => (
+    <>
+      {item.featured && (
+        <span className="featured-badge">
+          <span data-lang="ja">注目</span>
+          <span data-lang="en">Featured</span>
+        </span>
+      )}
+      {item.year && <span className="card-year">{item.year}</span>}
+      <div className="card-title">
+        <span data-lang="ja">{item.title.ja}</span>
+        <span data-lang="en">{item.title.en}</span>
+      </div>
+      {item.org && <div className="card-org">{item.org}</div>}
+    </>
+  )
+
   return (
     <div className="card-grid">
-      {items.map((item, index) => (
-        <a
-          key={index}
-          href={item.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={`card ${item.featured ? 'featured' : ''}`}
-        >
-          {item.featured && (
-            <span className="featured-badge">
-              <span data-lang="ja">注目</span>
-              <span data-lang="en">Featured</span>
-            </span>
-          )}
-          {item.year && <span className="card-year">{item.year}</span>}
-          <div className="card-title">
-            <span data-lang="ja">{item.title.ja}</span>
-            <span data-lang="en">{item.title.en}</span>
+      {items.map((item, index) =>
+        item.url ? (
+          <a
+            key={item.url || `${item.year}-${item.title.en}-${index}`}
+            href={item.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`card ${item.featured ? 'featured' : ''}`}
+          >
+            <CardContent item={item} />
+          </a>
+        ) : (
+          <div
+            key={`${item.year}-${item.title.en}-${index}`}
+            className={`card ${item.featured ? 'featured' : ''}`}
+          >
+            <CardContent item={item} />
           </div>
-          {item.org && <div className="card-org">{item.org}</div>}
-        </a>
-      ))}
+        )
+      )}
     </div>
   )
 }

--- a/src/components/CardGrid.jsx
+++ b/src/components/CardGrid.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+const CardGrid = ({ items, featured = false }) => {
+  return (
+    <div className="card-grid">
+      {items.map((item, index) => (
+        <a
+          key={index}
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`card ${item.featured ? 'featured' : ''}`}
+        >
+          {item.featured && (
+            <span className="featured-badge">
+              <span data-lang="ja">注目</span>
+              <span data-lang="en">Featured</span>
+            </span>
+          )}
+          {item.year && <span className="card-year">{item.year}</span>}
+          <div className="card-title">
+            <span data-lang="ja">{item.title.ja}</span>
+            <span data-lang="en">{item.title.en}</span>
+          </div>
+          {item.org && <div className="card-org">{item.org}</div>}
+        </a>
+      ))}
+    </div>
+  )
+}
+
+export default CardGrid

--- a/src/components/CompactList.jsx
+++ b/src/components/CompactList.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+const CompactList = ({ items }) => {
+  return (
+    <div className="compact-list">
+      {items.map((item, index) => (
+        <a
+          key={index}
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="list-item"
+        >
+          {item.icon && <div className="item-icon">{item.icon}</div>}
+          <div className="item-content">
+            <div className="item-title">
+              <span data-lang="ja">{item.title.ja}</span>
+              <span data-lang="en">{item.title.en}</span>
+            </div>
+            <div className="item-meta">
+              {item.venue && <span>{item.venue} • </span>}
+              {item.year && <span>{item.year}</span>}
+            </div>
+          </div>
+        </a>
+      ))}
+    </div>
+  )
+}
+
+export default CompactList

--- a/src/components/HighlightsBanner.jsx
+++ b/src/components/HighlightsBanner.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { highlights } from '../data/about-content'
+
+const HighlightsBanner = () => {
+  // Duplicate items for seamless infinite scroll
+  const duplicatedHighlights = [...highlights, ...highlights]
+
+  return (
+    <div className="highlights-banner">
+      <div className="highlights-track">
+        {duplicatedHighlights.map((highlight, index) => (
+          <div key={index} className="highlight-item">
+            <span data-lang="ja">{highlight.ja}</span>
+            <span data-lang="en">{highlight.en}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default HighlightsBanner

--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -15,11 +15,6 @@ const LanguageToggle = () => {
   useEffect(() => {
     localStorage.setItem('lang', lang)
     document.body.classList.toggle('lang-en', lang === 'en')
-
-    // Cleanup on unmount
-    return () => {
-      document.body.classList.remove('lang-en')
-    }
   }, [lang])
 
   return (

--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -1,19 +1,19 @@
 import React, { useState, useEffect } from 'react'
 
 const LanguageToggle = () => {
-  const [lang, setLang] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem('lang') || 'ja'
-    }
-    return 'ja'
-  })
+  const [lang, setLang] = useState('ja')
 
+  // Load saved language preference on mount (client-side only)
   useEffect(() => {
-    // Persist language preference
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('lang', lang)
+    const savedLang = localStorage.getItem('lang')
+    if (savedLang && savedLang !== lang) {
+      setLang(savedLang)
     }
-    // Apply language class to body
+  }, [])
+
+  // Persist language preference and apply body class
+  useEffect(() => {
+    localStorage.setItem('lang', lang)
     document.body.classList.toggle('lang-en', lang === 'en')
 
     // Cleanup on unmount

--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -1,0 +1,31 @@
+import React, { useState, useEffect } from 'react'
+
+const LanguageToggle = () => {
+  const [lang, setLang] = useState('ja')
+
+  useEffect(() => {
+    // Apply language class to body
+    document.body.classList.toggle('lang-en', lang === 'en')
+  }, [lang])
+
+  return (
+    <div className="lang-toggle">
+      <button
+        className={`lang-btn ${lang === 'ja' ? 'active' : ''}`}
+        onClick={() => setLang('ja')}
+        aria-label="Switch to Japanese"
+      >
+        日本語
+      </button>
+      <button
+        className={`lang-btn ${lang === 'en' ? 'active' : ''}`}
+        onClick={() => setLang('en')}
+        aria-label="Switch to English"
+      >
+        English
+      </button>
+    </div>
+  )
+}
+
+export default LanguageToggle

--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -1,11 +1,25 @@
 import React, { useState, useEffect } from 'react'
 
 const LanguageToggle = () => {
-  const [lang, setLang] = useState('ja')
+  const [lang, setLang] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('lang') || 'ja'
+    }
+    return 'ja'
+  })
 
   useEffect(() => {
+    // Persist language preference
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('lang', lang)
+    }
     // Apply language class to body
     document.body.classList.toggle('lang-en', lang === 'en')
+
+    // Cleanup on unmount
+    return () => {
+      document.body.classList.remove('lang-en')
+    }
   }, [lang])
 
   return (

--- a/src/components/TimelineSection.jsx
+++ b/src/components/TimelineSection.jsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import { speaking } from '../data/about-content'
+
+const TimelineSection = () => {
+  const [filter, setFilter] = useState('all')
+  const [showAll, setShowAll] = useState(false)
+
+  const filters = [
+    { value: 'all', label: { ja: 'すべて', en: 'All' } },
+    { value: '2025', label: { ja: '2025', en: '2025' } },
+    { value: '2024', label: { ja: '2024', en: '2024' } },
+    { value: '2023', label: { ja: '2023', en: '2023' } },
+    { value: 'older', label: { ja: 'それ以前', en: 'Earlier' } },
+  ]
+
+  const filterItems = (items) => {
+    if (filter === 'all') return items
+    if (filter === 'older') {
+      return items.filter(item => parseInt(item.year) < 2023)
+    }
+    return items.filter(item => item.year === filter)
+  }
+
+  const filteredItems = filterItems(speaking)
+  const displayedItems = showAll ? filteredItems : filteredItems.slice(0, 10)
+
+  return (
+    <div className="timeline-section">
+      <div className="filter-tabs">
+        {filters.map((f) => (
+          <button
+            key={f.value}
+            className={filter === f.value ? 'active' : ''}
+            onClick={() => setFilter(f.value)}
+            data-filter={f.value}
+          >
+            <span data-lang="ja">{f.label.ja}</span>
+            <span data-lang="en">{f.label.en}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="timeline">
+        {displayedItems.map((item, index) => {
+          const dateStr = item.month !== '00' ? `${item.year}/${item.month}` : item.year
+          return (
+            <div
+              key={index}
+              className="timeline-item"
+              data-year={item.year}
+            >
+              <div className="timeline-date">{dateStr}</div>
+              <div className="timeline-content">
+                <div className="timeline-title">
+                  {item.url ? (
+                    <a href={item.url} target="_blank" rel="noopener noreferrer">
+                      <span data-lang="ja">{item.title.ja}</span>
+                      <span data-lang="en">{item.title.en}</span>
+                    </a>
+                  ) : (
+                    <>
+                      <span data-lang="ja">{item.title.ja}</span>
+                      <span data-lang="en">{item.title.en}</span>
+                    </>
+                  )}
+                </div>
+                <div className="timeline-venue">{item.venue}</div>
+                {item.role && (
+                  <span className="timeline-role">{item.role}</span>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {filteredItems.length > 10 && !showAll && (
+        <button
+          className="show-more-btn"
+          onClick={() => setShowAll(true)}
+        >
+          <span data-lang="ja">もっと見る</span>
+          <span data-lang="en">Show More</span>
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default TimelineSection

--- a/src/components/TimelineSection.jsx
+++ b/src/components/TimelineSection.jsx
@@ -24,6 +24,11 @@ const TimelineSection = () => {
   const filteredItems = filterItems(speaking)
   const displayedItems = showAll ? filteredItems : filteredItems.slice(0, 10)
 
+  const handleFilterChange = (newFilter) => {
+    setFilter(newFilter)
+    setShowAll(false)
+  }
+
   return (
     <div className="timeline-section">
       <div className="filter-tabs">
@@ -31,7 +36,7 @@ const TimelineSection = () => {
           <button
             key={f.value}
             className={filter === f.value ? 'active' : ''}
-            onClick={() => setFilter(f.value)}
+            onClick={() => handleFilterChange(f.value)}
             data-filter={f.value}
           >
             <span data-lang="ja">{f.label.ja}</span>

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -1,5 +1,5 @@
 ---
-template: about-page
+template: about-page-redesign
 slug: /about
 title: About Me
 ---

--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -32,8 +32,7 @@ export const awards = [
       ja: 'CyberAgent 総会 2024 ベストコントリビューター賞',
       en: 'CyberAgent 2024 Best Contributor Award'
     },
-    org: 'CyberAgent',
-    url: ''
+    org: 'CyberAgent'
   },
 ]
 
@@ -166,8 +165,7 @@ export const speaking = [
       ja: 'デジタル世界のDEI ～AIバイアスのリアル～',
       en: 'DEI in Digital World: AI Bias Reality'
     },
-    venue: '日立社内セミナー',
-    url: ''
+    venue: '日立社内セミナー'
   },
   {
     year: '2023',

--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -1,0 +1,501 @@
+// Content data for About page redesign
+export const highlights = [
+  { ja: 'Women Developers Summit 2025 ベストスピーカー賞 1位', en: 'Best Speaker Award #1, Women Developers Summit 2025' },
+  { ja: 'Forbes JAPAN Women In Tech 30 選出', en: 'Forbes JAPAN Women In Tech 30' },
+  { ja: 'Women Techmakers Ambassador', en: 'Women Techmakers Ambassador' },
+  { ja: 'Tech DE&I プロジェクト リード', en: 'Tech DE&I Project Lead' },
+  { ja: '情報処理学会デジタルプラクティス論文採択', en: 'Published in IPSJ Digital Practice' },
+]
+
+export const awards = [
+  {
+    year: '2025',
+    title: {
+      ja: 'Women Developers Summit 2025 ベストスピーカー賞 1位',
+      en: 'Women Developers Summit 2025 Best Speaker Award #1'
+    },
+    org: 'Shoeisha',
+    url: 'https://www.cyberagent.co.jp/techinfo/news/detail/id=32274'
+  },
+  {
+    year: '2024',
+    title: {
+      ja: 'Forbes JAPAN Women In Tech 30 選出',
+      en: 'Forbes JAPAN Women In Tech 30'
+    },
+    org: 'Forbes JAPAN',
+    url: 'https://forbesjapan.com/articles/detail/74347/'
+  },
+  {
+    year: '2024',
+    title: {
+      ja: 'CyberAgent 総会 2024 ベストコントリビューター賞',
+      en: 'CyberAgent 2024 Best Contributor Award'
+    },
+    org: 'CyberAgent',
+    url: ''
+  },
+]
+
+export const speaking = [
+  {
+    year: '2025',
+    month: '06',
+    title: {
+      ja: 'AIエージェントの力で切り拓く、誰もが活躍できるインクルーシブな未来',
+      en: 'Creating an Inclusive Future with AI Agents'
+    },
+    venue: 'Women Developers Summit 2025',
+    url: 'https://event.shoeisha.jp/devsumi/20250627/session/5829'
+  },
+  {
+    year: '2025',
+    month: '06',
+    title: {
+      ja: 'ジェンダーギャップの"今"と"これから" 〜テック業界で私たちが切り拓く新しい未来〜',
+      en: 'Gender Gap: Present and Future in Tech Industry'
+    },
+    venue: 'BoxWorks TOKYO 2025',
+    url: 'https://www.box-events.jp/boxworks2025_tokyo/day1_timetable'
+  },
+  {
+    year: '2025',
+    month: '04',
+    title: {
+      ja: 'International Women\'s Day 2025',
+      en: 'International Women\'s Day 2025'
+    },
+    venue: 'OutSystems Japan Community',
+    url: 'https://usergroups.outsystems.com/events/details/outsystems-inc-tokyo-presents-iwd-international-womens-day-2025-outsystems-japan-community/'
+  },
+  {
+    year: '2024',
+    month: '11',
+    title: {
+      ja: '多事業展開を成功させる横断開発の秘訣',
+      en: 'Secrets of Cross-Functional Development for Multi-Business Success'
+    },
+    venue: 'プロダクトヒストリーカンファレンス',
+    role: 'モデレーター',
+    url: 'https://lp-a.youtrust.jp/phc2024/'
+  },
+  {
+    year: '2024',
+    month: '11',
+    title: {
+      ja: 'アプリ甲子園 審査員',
+      en: 'App Koshien Judge'
+    },
+    venue: 'アプリ甲子園',
+    url: 'https://applikoshien.jp/2024result'
+  },
+  {
+    year: '2024',
+    month: '10',
+    title: {
+      ja: 'グローバル展開を見据えたサービスにおける機械翻訳プラクティス',
+      en: 'Machine Translation Practices for Global Services'
+    },
+    venue: 'CADC 2024',
+    url: 'https://cadc.cyberagent.co.jp/2024/sessions/dp-ai-translating/'
+  },
+  {
+    year: '2024',
+    month: '08',
+    title: {
+      ja: 'テックカンファレンスに女性登壇者を増やす意義',
+      en: 'Importance of Increasing Female Speakers at Tech Conferences'
+    },
+    venue: 'WAKE Career',
+    url: 'https://wake-career.connpass.com/event/327617/'
+  },
+  {
+    year: '2024',
+    month: '07',
+    title: {
+      ja: '未来の仕事を知ろう：女子と保護者のための進路セミナー',
+      en: 'Career Seminar for Girls and Parents'
+    },
+    venue: '山田進太郎 D&I 財団',
+    url: 'https://www.shinfdn.org/posts/IqchcA6x'
+  },
+  {
+    year: '2024',
+    month: '04',
+    title: {
+      ja: '子育てエンジニアのためのキャリア会議',
+      en: 'Career Conference for Parent Engineers'
+    },
+    venue: 'Forkwell',
+    url: 'https://forkwell.connpass.com/event/313545/'
+  },
+  {
+    year: '2023',
+    month: '07',
+    title: {
+      ja: '生成AIの話題にイマイチついていけない人のためのChatGPT体験講座',
+      en: 'ChatGPT Workshop for Beginners'
+    },
+    venue: 'みんなのコード',
+    url: 'https://code.or.jp/event/20230615/'
+  },
+  {
+    year: '2023',
+    month: '06',
+    title: {
+      ja: 'CyberAgentにおける多様性の価値とは？',
+      en: 'The Value of Diversity at CyberAgent'
+    },
+    venue: 'GitHub Galaxy Tokyo',
+    url: 'https://resources.github.com/galaxy/tokyo/'
+  },
+  {
+    year: '2023',
+    month: '04',
+    title: {
+      ja: 'My #DareToBe Story エンジニア組織のDE&I推進を目指して',
+      en: 'My #DareToBe Story: Promoting DE&I in Engineering Organizations'
+    },
+    venue: 'WTM Tokyo - IWD 2023',
+    url: 'https://gdg-tokyo.connpass.com/event/277960/'
+  },
+  {
+    year: '2023',
+    month: '03',
+    title: {
+      ja: 'デジタル世界のDEI ～AIバイアスのリアル～',
+      en: 'DEI in Digital World: AI Bias Reality'
+    },
+    venue: '日立社内セミナー',
+    url: ''
+  },
+  {
+    year: '2023',
+    month: '01',
+    title: {
+      ja: 'キャリアパスの多様性',
+      en: 'Diversity in Career Paths'
+    },
+    venue: '第3回インダストリアルAIシンポジウム',
+    url: 'https://www.ai-gakkai.or.jp/siai/program/lecture'
+  },
+  {
+    year: '2022',
+    month: '09',
+    title: {
+      ja: '技育展 2022「女性エンジニア」テーマ審査員',
+      en: 'Geekten 2022 "Female Engineers" Theme Judge'
+    },
+    venue: '技育展',
+    url: 'https://talent.supporterz.jp/geekten/2022/'
+  },
+  {
+    year: '2022',
+    month: '05',
+    title: {
+      ja: '文系女性の可能性を広げる、エンジニアという選択肢。',
+      en: 'Engineering as a Career Choice for Liberal Arts Women'
+    },
+    venue: 'Business with Attitude',
+    url: 'https://madamefigaro.jp/society-business/220525-bwa-yu-kamiya.html'
+  },
+  {
+    year: '2022',
+    month: '04',
+    title: {
+      ja: 'プログラミング教育、エンジニアへの道',
+      en: 'Programming Education and the Path to Engineering'
+    },
+    venue: '母親アップデートラジオ',
+    url: 'https://voicy.jp/channel/989/312990'
+  },
+  {
+    year: '2022',
+    month: '03',
+    title: {
+      ja: '未来の学校 FES 理系女子のミライ',
+      en: 'Future School FES: Future of Women in STEM'
+    },
+    venue: '神山まるごと高専',
+    url: 'https://www.youtube.com/watch?app=desktop&v=PQr7XGH0hOg'
+  },
+  {
+    year: '2021',
+    month: '11',
+    title: {
+      ja: 'IT分野のジェンダーギャップの現在地とアクション',
+      en: 'Current State and Actions on Gender Gap in IT'
+    },
+    venue: 'Women Developers Summit',
+    url: 'https://event.shoeisha.jp/devsumi/20211117/session/3515/'
+  },
+  {
+    year: '2021',
+    month: '11',
+    title: {
+      ja: '副業で広がるキャリアの可能性と働き方の選択肢',
+      en: 'Career Possibilities Through Side Jobs'
+    },
+    venue: 'BIT VALLEY 2021',
+    url: 'https://2021.bit-valley.jp/program/career/35'
+  },
+  {
+    year: '2021',
+    month: '00',
+    title: {
+      ja: 'Women in Tech Meetup Vol.03',
+      en: 'Women in Tech Meetup Vol.03'
+    },
+    venue: 'Mercari',
+    url: 'https://connpass.com/event/201048/'
+  },
+  {
+    year: '2020',
+    month: '00',
+    title: {
+      ja: 'テクノロジー業界における女性のリーダーシップを支援するため',
+      en: 'Supporting Women\'s Leadership in Technology Industry'
+    },
+    venue: 'Wahl & Case',
+    url: 'https://www.wahlandcase.com/jp/webinar/women-leaders-in-the-technology-industry'
+  },
+  {
+    year: '2020',
+    month: '00',
+    title: {
+      ja: 'Waffle Camp キャリアトーク',
+      en: 'Waffle Camp Career Talk'
+    },
+    venue: 'Waffle Camp',
+    url: 'https://www.camp.waffle-waffle.org/'
+  },
+  {
+    year: '2019',
+    month: '00',
+    title: {
+      ja: 'Woman Tech Terrace LT',
+      en: 'Woman Tech Terrace LT'
+    },
+    venue: 'CyberAgent',
+    url: 'https://wtt.cyberagent.group/'
+  },
+]
+
+export const organizedEvents = [
+  {
+    year: '2025',
+    title: {
+      ja: 'Women Tech Terrace 2025',
+      en: 'Women Tech Terrace 2025'
+    },
+    org: 'CyberAgent',
+    url: 'https://www.cyberagent.co.jp/way/list/detail/id=32213'
+  },
+  {
+    year: '2025',
+    title: {
+      ja: 'CA Women Tech Meetup',
+      en: 'CA Women Tech Meetup'
+    },
+    org: 'CyberAgent',
+    url: 'https://developers.cyberagent.co.jp/blog/archives/55660/'
+  },
+  {
+    year: '2024',
+    title: {
+      ja: 'Women Tech Terrace 2024',
+      en: 'Women Tech Terrace 2024'
+    },
+    org: 'CyberAgent',
+    url: 'https://www.cyberagent.co.jp/way/list/detail/id=30486'
+  },
+  {
+    year: '2023',
+    title: {
+      ja: 'Women Tech Terrace 2023',
+      en: 'Women Tech Terrace 2023'
+    },
+    org: 'CyberAgent',
+    url: 'https://www.cyberagent.co.jp/way/list/detail/id=28827'
+  },
+]
+
+export const research = [
+  {
+    icon: '📄',
+    title: {
+      ja: 'IT技術者のジェンダーギャップ解消のための志望者・現役技術者に対する調査',
+      en: 'Survey on Gender Gap in IT: Aspirants and Professionals'
+    },
+    venue: '情報処理学会デジタルプラクティス',
+    year: '2024',
+    url: 'https://www.ipsj.or.jp/dp/contents/publication/61/TR0601-13.html'
+  },
+  {
+    icon: '🎤',
+    title: {
+      ja: 'ソフトウェアエンジニア志望者における男女差: ロールモデル・会社選びの基準・興味関心',
+      en: 'Gender Differences in Software Engineering Aspirants'
+    },
+    venue: '人工知能学会全国大会（JSAI2024）',
+    year: '2024',
+    url: 'https://www.cyberagent.co.jp/techinfo/news/detail/id=30165'
+  },
+  {
+    icon: '📊',
+    title: {
+      ja: 'IT製品の開発に携わる従業員に対する、就労環境の包摂度調査について',
+      en: 'Survey on Inclusivity in IT Product Development Environments'
+    },
+    venue: '経営情報学会 2023',
+    year: '2023',
+    url: 'https://www.cyberagent.co.jp/techinfo/news/detail/id=29456'
+  },
+]
+
+export const writing = [
+  {
+    icon: '✍️',
+    title: {
+      ja: 'サイバーエージェントのディベロッパーコミュニティ活性化とDE&Iの取り組み',
+      en: 'CyberAgent Developer Community and DE&I Initiatives'
+    },
+    year: '2025',
+    url: 'https://developers.cyberagent.co.jp/blog/archives/51796/'
+  },
+  {
+    icon: '🌐',
+    title: {
+      ja: 'グローバル展開を見据えたサービスにおける機械翻訳プラクティス',
+      en: 'Machine Translation Practices for Global Services'
+    },
+    year: '2024',
+    url: 'https://developers.cyberagent.co.jp/blog/archives/50516/'
+  },
+  {
+    icon: '🤖',
+    title: {
+      ja: '子ども向けプログラミング学習サービスの多言語翻訳における生成AI活用の可能性',
+      en: 'Potential of Generative AI in Multilingual Translation for Kids\' Programming Services'
+    },
+    year: '2023',
+    url: 'https://developers.cyberagent.co.jp/blog/archives/44530/'
+  },
+  {
+    icon: '👩‍💻',
+    title: {
+      ja: 'ママエンジニアのワークライフ',
+      en: 'Work-Life of a Mother Engineer'
+    },
+    year: '2015',
+    url: 'https://ameblo.jp/principia-ca/entry-12071778409.html'
+  },
+]
+
+export const media = [
+  {
+    icon: '📰',
+    title: {
+      ja: '朝日新聞：（凄腕ものがたり）神谷優さん　エンジニアの男女格差解消に挑む',
+      en: 'Asahi Shimbun: Yu Kamiya Tackles Gender Gap in Engineering'
+    },
+    year: '2025',
+    url: 'https://www.asahi.com/articles/DA3S16241559.html'
+  },
+  {
+    icon: '💼',
+    title: {
+      ja: 'サイバーエージェント Tech DE&I プロジェクトの今',
+      en: 'CyberAgent Tech DE&I Project Update'
+    },
+    year: '2025',
+    url: 'https://www.cyberagent.co.jp/way/list/detail/id=31500'
+  },
+  {
+    icon: '🏆',
+    title: {
+      ja: 'Forbes: サイバーエージェントが挑む「Tech DE&I」の舞台裏',
+      en: 'Forbes: Behind CyberAgent\'s Tech DE&I Initiatives'
+    },
+    year: '2024',
+    url: 'https://forbesjapan.com/articles/detail/74649'
+  },
+  {
+    icon: '📖',
+    title: {
+      ja: 'SELECK: IT業界のジェンダーギャップ解消に挑む',
+      en: 'SELECK: Tackling Gender Gap in IT Industry'
+    },
+    year: '2023',
+    url: 'https://seleck.cc/1608'
+  },
+  {
+    icon: '📝',
+    title: {
+      ja: 'CodeZine: 女性エンジニアが増えたほうが良い理由とは？',
+      en: 'CodeZine: Why We Need More Female Engineers'
+    },
+    year: '2023',
+    url: 'https://codezine.jp/article/detail/16896'
+  },
+]
+
+export const podcasts = [
+  {
+    title: {
+      ja: 'fukabori.fm #129: Tech業界のDE&Iの現状と課題',
+      en: 'fukabori.fm #129: DE&I in Tech Industry'
+    },
+    featured: true,
+    url: 'https://fukabori.fm/episode/129'
+  },
+  {
+    title: {
+      ja: 'SKO radio ゲスト出演 Part1',
+      en: 'SKO radio Guest Appearance Part1'
+    },
+    url: 'https://open.spotify.com/episode/40E0B50d4s8qg9YSrvfFak'
+  },
+  {
+    title: {
+      ja: 'SKO radio ゲスト出演 Part2',
+      en: 'SKO radio Guest Appearance Part2'
+    },
+    url: 'https://open.spotify.com/episode/43LcwLt7qKsZG6ev4qAdMZ'
+  },
+]
+
+export const links = [
+  {
+    name: {
+      ja: 'はてなブログ',
+      en: 'Hatena Blog'
+    },
+    url: 'https://fuzzy31u.hatenablog.com/',
+    icon: 'hatena'
+  },
+  {
+    name: {
+      ja: 'Qiita',
+      en: 'Qiita'
+    },
+    url: 'https://qiita.com/fuzzy31u',
+    icon: 'qiita'
+  },
+  {
+    name: {
+      ja: 'SpeakerDeck',
+      en: 'SpeakerDeck'
+    },
+    url: 'https://speakerdeck.com/fuzzy31u',
+    icon: 'speakerdeck'
+  },
+  {
+    name: {
+      ja: 'Zenn',
+      en: 'Zenn'
+    },
+    url: 'https://zenn.dev/yukamiya',
+    icon: 'zenn'
+  },
+]

--- a/src/templates/about-page-redesign.js
+++ b/src/templates/about-page-redesign.js
@@ -1,0 +1,146 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+import Layout from "../components/layout"
+import Seo from "../components/seo"
+import LanguageToggle from "../components/LanguageToggle"
+import AboutHero from "../components/AboutHero"
+import HighlightsBanner from "../components/HighlightsBanner"
+import CardGrid from "../components/CardGrid"
+import CompactList from "../components/CompactList"
+import TimelineSection from "../components/TimelineSection"
+
+import { awards, organizedEvents, research, writing, media, podcasts, links } from "../data/about-content"
+import "../assets/scss/about.scss"
+
+export const pageQuery = graphql`
+  query AboutRedesignQuery($id: String!) {
+    markdownRemark(id: { eq: $id }) {
+      id
+      excerpt(pruneLength: 140)
+      frontmatter {
+        title
+      }
+    }
+  }
+`
+
+const AboutPageRedesign = ({ data }) => {
+  const { markdownRemark } = data
+  const { frontmatter, excerpt } = markdownRemark
+
+  return (
+    <Layout className="page">
+      <Seo title={frontmatter.title} description={excerpt} />
+      <div className="about-page-redesign">
+        <div className="container">
+          <LanguageToggle />
+          <AboutHero />
+        </div>
+
+        <HighlightsBanner />
+
+        {/* Awards Section */}
+        <section className="about-section">
+          <h2>
+            <span data-lang="ja">受賞 / Awards</span>
+            <span data-lang="en">Awards</span>
+          </h2>
+          <CardGrid items={awards} />
+        </section>
+
+        {/* Speaking Section */}
+        <section className="about-section">
+          <h2>
+            <span data-lang="ja">登壇 / Public Speaking</span>
+            <span data-lang="en">Public Speaking</span>
+          </h2>
+          <TimelineSection />
+        </section>
+
+        {/* Organized Events Section */}
+        <section className="about-section">
+          <h2>
+            <span data-lang="ja">主催イベント / Organized Events</span>
+            <span data-lang="en">Organized Events</span>
+          </h2>
+          <CardGrid items={organizedEvents} />
+        </section>
+
+        {/* Research Section */}
+        <section className="about-section">
+          <h2>
+            <span data-lang="ja">論文 / Research</span>
+            <span data-lang="en">Research</span>
+          </h2>
+          <CompactList items={research} />
+        </section>
+
+        {/* Writing Section */}
+        <section className="about-section">
+          <h2>
+            <span data-lang="ja">執筆 / Writing</span>
+            <span data-lang="en">Writing</span>
+          </h2>
+          <CompactList items={writing} />
+        </section>
+
+        {/* Media Section */}
+        <section className="about-section">
+          <h2>
+            <span data-lang="ja">掲載 / Media</span>
+            <span data-lang="en">Media</span>
+          </h2>
+          <CompactList items={media} />
+        </section>
+
+        {/* Podcast Section */}
+        <section className="about-section">
+          <h2>
+            <span data-lang="ja">ポッドキャスト / Podcasts</span>
+            <span data-lang="en">Podcasts</span>
+          </h2>
+          <CardGrid items={podcasts} />
+        </section>
+
+        {/* Links Section */}
+        <section className="links-section">
+          <h2>
+            <span data-lang="ja">リンク / Links</span>
+            <span data-lang="en">Links</span>
+          </h2>
+          <div className="links-grid">
+            {links.map((link, index) => (
+              <a
+                key={index}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="link-card"
+              >
+                <div className="link-icon">
+                  {/* Simple icon placeholder - can be replaced with actual SVG icons */}
+                  <svg width="32" height="32" viewBox="0 0 32 32" fill="currentColor">
+                    <circle cx="16" cy="16" r="14" opacity="0.3"/>
+                    <text x="16" y="20" textAnchor="middle" fontSize="16" fill="currentColor">
+                      {link.icon === 'hatena' && 'B'}
+                      {link.icon === 'qiita' && 'Q'}
+                      {link.icon === 'speakerdeck' && 'S'}
+                      {link.icon === 'zenn' && 'Z'}
+                    </text>
+                  </svg>
+                </div>
+                <div className="link-name">
+                  <span data-lang="ja">{link.name.ja}</span>
+                  <span data-lang="en">{link.name.en}</span>
+                </div>
+              </a>
+            ))}
+          </div>
+        </section>
+      </div>
+    </Layout>
+  )
+}
+
+export default AboutPageRedesign


### PR DESCRIPTION
Implements modern, bilingual-friendly About page redesign as specified in issue #18.

## Changes
- Added Google Fonts integration
- Created 6 new React components for different sections
- Implemented bilingual content switching
- Added CSS design tokens and animations
- Created structured content data file
- Fully responsive design

Closes #18

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redesigns the About page with a new Gatsby template, bilingual UI components, structured content data, responsive styles, and Google Fonts.
> 
> - **About Page Redesign**:
>   - **New template**: `src/templates/about-page-redesign.js` rendering sections (Awards, Speaking, Organized Events, Research, Writing, Media, Podcasts, Links).
>   - **New components**: `LanguageToggle` (localStorage + body class), `AboutHero`, `HighlightsBanner` (infinite scroll), `CardGrid`, `CompactList`, `TimelineSection` (filters + show more).
> - **Styles**:
>   - **SCSS**: `src/assets/scss/about.scss` with design tokens, animations, grids, and responsive rules.
> - **Content**:
>   - **Data module**: `src/data/about-content.js` providing structured bilingual content for all sections.
>   - **Markdown**: `src/content/pages/about.md` switched to `about-page-redesign` template and updated copy.
> - **Gatsby setup**:
>   - **Fonts**: `gatsby-browser.js` `onClientEntry` injects Google Fonts for redesign.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ffa09c8fbea023f47c497e47c2c9793ad1a024d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->