### PR TITLE
feat: implement v2 redesign for contact page

### DIFF
--- a/src/templates/contact-page.js
+++ b/src/templates/contact-page.js
@@ -1,5 +1,4 @@
-/** @jsx jsx */
-import { jsx } from "theme-ui"
+import React from "react"
 import { graphql } from "gatsby"
 import { RiSendPlane2Line } from "react-icons/ri"
 
@@ -16,24 +15,16 @@ export const pageQuery = graphql`
         title
       }
     }
-    site {
-      siteMetadata {
-        title
-      }
-    }
   }
 `
 
 const Contact = ({ data }) => {
-  const { markdownRemark, site } = data // data.markdownRemark holds your post data
-  const { frontmatter, html } = markdownRemark
+  const { markdownRemark } = data // data.markdownRemark holds your post data
+  const { frontmatter, html, excerpt } = markdownRemark
 
   return (
-    <Layout className="contact-page" sx={contactStyles.contactPage}>
-      <Seo
-        title={frontmatter.title}
-        description={frontmatter.title + " " + site.siteMetadata.title}
-      />
+    <Layout className="contact-page">
+      <Seo title={frontmatter.title} description={excerpt} />
       <div className="wrapper">
         <h1>{frontmatter.title}</h1>
         <div
@@ -73,13 +64,7 @@ const Contact = ({ data }) => {
             </label>
           </p>
           <p className="text-align-right">
-            <button
-              className="button"
-              sx={{
-                variant: "variants.button",
-              }}
-              type="submit"
-            >
+            <button className="button" type="submit">
               Send Message{" "}
               <span className="icon -right">
                 <RiSendPlane2Line />
@@ -93,20 +78,3 @@ const Contact = ({ data }) => {
 }
 
 export default Contact
-
-const contactStyles = {
-  contactPage: {
-    input: {
-      border: "6px solid",
-      borderColor: "inputBorder",
-      bg: "inputBackground",
-      outline: "none",
-    },
-    textarea: {
-      border: "6px solid",
-      borderColor: "inputBorder",
-      bg: "inputBackground",
-      outline: "none",
-    },
-  },
-}


### PR DESCRIPTION
Simplify contact page template following v2 redesign pattern:
- Remove Theme UI jsx pragma and sx prop usage
- Replace with standard React imports
- Remove site metadata from query (not needed)
- Simplify Seo component to use excerpt
- Remove custom contactStyles object (16 lines)
- Clean up button styling to use className only

Contact form functionality remains fully intact.

Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the contact page by removing Theme UI, trimming the query, and using excerpt-driven SEO with cleaned props.
> 
> - **Contact page template (`src/templates/contact-page.js`)**:
>   - Replace Theme UI pragma/`sx` usage with standard React; remove `contactStyles` and inline `sx` props.
>   - Trim GraphQL query: drop `site.siteMetadata` and add `excerpt(pruneLength: 140)`; update component to use `excerpt`.
>   - Simplify `<Seo>` props: `description` now from `excerpt`; remove dependency on site metadata.
>   - Clean up button and layout props: use `className` only; remove `sx` on `Layout` and button.
>   - Minor refactor: adjust destructuring to include `excerpt`; keep form structure and behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e5280693e14e7b2065f0ba22439d5405e72d905. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->