### PR TITLE
feat: コンテンツ追加の自動化 (Issue テンプレート + Claude 連携)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Content Addition Help
+    url: https://github.com/fuzzy31u/yukamiya.me/blob/main/CLAUDE.md
+    about: コンテンツ更新のガイドライン

--- a/.github/ISSUE_TEMPLATE/content-addition-awards.yml
+++ b/.github/ISSUE_TEMPLATE/content-addition-awards.yml
@@ -1,0 +1,63 @@
+name: "Add Award"
+description: "受賞歴を About ページに追加"
+title: "@claude Add Award: [受賞名]"
+labels: ["content-addition", "awards"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 受賞歴の追加
+        以下のフォームに入力してください。Claude が自動で PR を作成します。
+
+  - type: input
+    id: year
+    attributes:
+      label: Year
+      description: "受賞年 (例: 2025)"
+      placeholder: "2025"
+    validations:
+      required: true
+
+  - type: input
+    id: title_ja
+    attributes:
+      label: Award Name (Japanese)
+      description: "受賞名（日本語）"
+      placeholder: "Women Developers Summit 2025 ベストスピーカー賞 1位"
+    validations:
+      required: true
+
+  - type: input
+    id: title_en
+    attributes:
+      label: Award Name (English)
+      description: "受賞名（英語）"
+      placeholder: "Women Developers Summit 2025 Best Speaker Award #1"
+    validations:
+      required: true
+
+  - type: input
+    id: org
+    attributes:
+      label: Organization
+      description: "授与組織"
+      placeholder: "Shoeisha"
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      description: "発表ページの URL（任意）"
+      placeholder: "https://example.com/award"
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Notes
+      description: "その他の補足情報（任意）"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/content-addition-media.yml
+++ b/.github/ISSUE_TEMPLATE/content-addition-media.yml
@@ -1,0 +1,69 @@
+name: "Add Media Coverage"
+description: "メディア掲載を About ページに追加"
+title: "@claude Add Media: [メディア名]"
+labels: ["content-addition", "media"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## メディア掲載の追加
+        以下のフォームに入力してください。Claude が自動で PR を作成します。
+
+  - type: input
+    id: year
+    attributes:
+      label: Year
+      description: "掲載年 (例: 2025)"
+      placeholder: "2025"
+    validations:
+      required: true
+
+  - type: input
+    id: title_ja
+    attributes:
+      label: Title (Japanese)
+      description: "記事タイトル（日本語）"
+      placeholder: "日経クロスウーマン：記事タイトル"
+    validations:
+      required: true
+
+  - type: input
+    id: title_en
+    attributes:
+      label: Title (English)
+      description: "記事タイトル（英語）"
+      placeholder: "Nikkei xWoman: Article Title"
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      description: "記事の URL"
+      placeholder: "https://example.com/article"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: icon
+    attributes:
+      label: Icon
+      description: "アイコンを選択"
+      options:
+        - "📰 新聞・ニュース"
+        - "📖 雑誌・書籍"
+        - "👩‍💼 インタビュー"
+        - "💼 ビジネス"
+        - "🎙️ ラジオ・音声"
+        - "📺 テレビ・動画"
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Notes
+      description: "その他の補足情報（任意）"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/content-addition-speaking.yml
+++ b/.github/ISSUE_TEMPLATE/content-addition-speaking.yml
@@ -1,0 +1,81 @@
+name: "Add Speaking Content"
+description: "登壇情報を About ページに追加"
+title: "@claude Add Speaking: [イベント名]"
+labels: ["content-addition", "speaking"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 登壇情報の追加
+        以下のフォームに入力してください。Claude が自動で PR を作成します。
+
+  - type: input
+    id: year
+    attributes:
+      label: Year
+      description: "イベントの年 (例: 2025)"
+      placeholder: "2025"
+    validations:
+      required: true
+
+  - type: input
+    id: month
+    attributes:
+      label: Month
+      description: "月 (01-12、不明な場合は 00)"
+      placeholder: "06"
+    validations:
+      required: true
+
+  - type: input
+    id: title_ja
+    attributes:
+      label: Title (Japanese)
+      description: "登壇タイトル（日本語）"
+      placeholder: "AIエージェント時代のチームコラボレーション"
+    validations:
+      required: true
+
+  - type: input
+    id: title_en
+    attributes:
+      label: Title (English)
+      description: "登壇タイトル（英語）"
+      placeholder: "Team Collaboration in the AI Agent Era"
+    validations:
+      required: true
+
+  - type: input
+    id: venue
+    attributes:
+      label: Venue/Event Name
+      description: "イベント名または会場名"
+      placeholder: "Women Developers Summit 2025"
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      description: "イベントページの URL（任意）"
+      placeholder: "https://example.com/event"
+    validations:
+      required: false
+
+  - type: input
+    id: role
+    attributes:
+      label: Role
+      description: "役割（任意、例: モデレーター、審査員）"
+      placeholder: "モデレーター"
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Notes
+      description: "その他の補足情報（任意）"
+    validations:
+      required: false

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
          github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary

- GitHub Issue テンプレートを追加し、フォーム入力でコンテンツ追加リクエストを作成可能に
- `claude.yml` ワークフローを更新し、Issue から PR 自動作成に対応

## 変更内容

### Issue テンプレート (新規作成)
- `content-addition-speaking.yml` - 登壇情報追加用
- `content-addition-media.yml` - メディア掲載追加用  
- `content-addition-awards.yml` - 受賞歴追加用
- `config.yml` - テンプレート設定

### ワークフロー更新
- `contents: write` - PR 作成権限を追加
- `fetch-depth: 0` - ブランチ操作のため全履歴取得

## 使い方

1. GitHub で "New Issue" をクリック
2. "Add Speaking Content" 等のテンプレートを選択
3. フォームに入力して送信
4. Claude Code が自動で PR を作成

## Test plan

- [ ] Issue テンプレートが GitHub UI に表示される
- [ ] フォーム入力で Issue 作成可能
- [ ] `@claude` を含む Issue で Claude Code が起動
- [ ] PR が自動作成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds structured content submission via Issues and enables Claude to open PRs based on those issues.
> 
> - New issue templates: `content-addition-speaking.yml`, `content-addition-media.yml`, `content-addition-awards.yml`; template config in `config.yml` with contact link
> - Update `claude.yml` workflow: set `permissions.contents: write` and checkout `fetch-depth: 0` to allow PR creation and full git history access
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d238bbca6ed3fe991a7eb7afe96746e5355255. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->