### PR TITLE
fix: remove duplicated hero and highlights from About page

### DIFF
--- a/src/assets/scss/about.scss
+++ b/src/assets/scss/about.scss
@@ -208,6 +208,10 @@ body.lang-en .bilingual .en { display: inline; }
   margin: 0 auto;
   padding: var(--spacing-lg) var(--spacing-md);
 
+  &:first-child {
+    padding-top: var(--spacing-xl);
+  }
+
   .section-header {
     display: flex;
     justify-content: space-between;

--- a/src/templates/about-page-redesign.js
+++ b/src/templates/about-page-redesign.js
@@ -3,8 +3,6 @@ import { graphql } from "gatsby"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
-import AboutHero from "../components/AboutHero"
-import HighlightsBanner from "../components/HighlightsBanner"
 import CardGrid from "../components/CardGrid"
 import CompactList from "../components/CompactList"
 import TimelineSection from "../components/TimelineSection"
@@ -32,12 +30,6 @@ const AboutPageRedesign = ({ data }) => {
     <Layout className="page">
       <Seo title={frontmatter.title} description={excerpt} />
       <div className="about-page-redesign">
-        <div className="container">
-          <AboutHero />
-        </div>
-
-        <HighlightsBanner />
-
         {/* Awards Section */}
         <section className="about-section">
           <h2>


### PR DESCRIPTION
Remove the hero container and HighlightsBanner from the About page to eliminate redundancy with the Home page.

Fixes #36

## Changes
- Remove AboutHero and HighlightsBanner imports
- Remove hero container wrapper and HighlightsBanner component
- Add top padding to first section for proper spacing

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes duplicated hero/highlights from the About page and compensates spacing.
> 
> - Deletes `AboutHero` and `HighlightsBanner` imports/usages from `about-page-redesign.js`
> - Adds `.about-section:first-child { padding-top: var(--spacing-xl); }` in `about.scss` to restore top spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9be1ef0d8ad686155a49126dbe46ee17915eebf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->