### PR TITLE
docs: update README to reflect yukamiya.me site structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,176 +1,140 @@
-> **Update** Foundation is now built with Gatsby V4, this include many performance update
+# yukamiya.me
 
----
+Personal website for Yu Kamiya, a software engineer. This is a bilingual (English/Japanese) site featuring a blog and personal information.
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/63521b78-612e-4a2f-a409-3fa8009e7f3b/deploy-status)](https://app.netlify.com/sites/frosty-perlman-9da1cb/deploys) &nbsp;<a href="https://twitter.com/intent/follow?screen_name=stackrole">
-<img src="https://img.shields.io/twitter/follow/stackrole.svg?label=Follow%20@Stackrole" alt="Follow @stackrole" />
-</a>
+[![Netlify Status](https://api.netlify.com/api/v1/badges/63521b78-612e-4a2f-a409-3fa8009e7f3b/deploy-status)](https://app.netlify.com/sites/frosty-perlman-9da1cb/deploys)
 
-# Foundation
+**Live Site:** [yukamiya.me](https://yukamiya.me)
 
-A starter to launch your blazing fast personal website and a blog, Built with [Gatsby][gatsby] and [Netlify CMS][netlifycms].
+## About This Site
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/stackrole/gatsby-starter-foundation)
+This website is built with Gatsby v4 and features:
 
-Need help launching your website? My DM's are open on <a href="https://twitter.com/stackrole">twitter</a>
+- **Bilingual Content**: Full support for English and Japanese content
+- **Blog Posts**: Markdown-based blog posts with frontmatter
+- **Static Pages**: About, Contact, and Index pages
+- **Content Management**: Netlify CMS for easy content editing
+- **Theme Support**: Dark/light mode with Theme UI
+- **Search**: ElasticLunr-powered search functionality
+- **Responsive Design**: Mobile-friendly SCSS styling
+- **SEO Optimized**: OpenGraph, Twitter Cards, and XML sitemaps
 
-[![Gatsby Starter Foundation Screenshot](static/assets/gatsby-starter-foundation-light-mode.jpg)](https://foundation.stackrole.com)
+## Development
 
-## 👌 Features
+### Prerequisites
 
-- A Blog and Personal website with Netlify CMS.
-- Responsive Web Design
-- Dark / Light Mode
-- Customize theme color from CMS
+- Node.js (v14.15.0 or higher)
+- npm
 
-    ![gatsby-starter-foundation-dark-mode.jpg](https://media.giphy.com/media/Pb4yImVfcF6MDYuuGm/giphy.gif)
+### Getting Started
 
-- Search bar
-- Customize content of Homepage, About and Contact page.
-- Customize content of Homepage, About and Contact page.
-- Add / Modify / Delete blog posts.
-- Edit website settings, Add Google Analytics and make it your own all with in the CMS.
-- SEO Optimized
-- Social media icons
-- OpenGraph structured data
-- Twitter Cards meta
-- Beautiful XML Sitemaps
-- Netlify Contact Form, Works right out of the box after deployment.
-- Invite collaborators into Netlify CMS, without giving access to your Github account via Git Gateway
-- Gatsby Incremental Builds with Netlify.
-
-[![Gatsby Starter Foundation Screenshot](static/assets/gatsby-starter-foundation-dark-mode.jpg)](https://foundation.stackrole.com)
-
-## 🚀 Quick Deploy
-
-Just click on the **Deploy to Netlify** button.
-
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/stackrole/gatsby-starter-foundation)
-
-This would fork `gatsby-starter-foundation` to your Github account and start building your website on [Netlify](https://netlify.com). Once the deployment is done. Your website will be live and website address would look like **site-name.netlify.app**
-
-### Further Instructions
-
-- [Access to Netlify CMS](#access-to-netlify-cms)
-- [Editing content and Adding posts](#editing-content-and-adding-posts)
-- [Customing Site details](#customing-site-details)
-- [Adding Custom domain to netlify website](#adding-custom-domain-to-netlify-website)
-- [Install Locally](#install-locally)
-- [Folder Structure](#folder-structure)
-- [Learning Gatsby](#learning-gatsby)
-- [Thank you from Stackrole](#thank-you)
-
-## ⚙ Access to Netlify CMS
-
-- Goto app.netlify.com > select your website from the list
-- Goto identity and Click **Enable Identiy**
-- Click on **Invite Users** and invite yourself. You will receive an email and you need to accept the invitation to set the password.
-- Now headover to Settings > Identity > Services and **Enable Git Gateway**
-- You can also manage who can register and log in to your CMS. Goto Settings > Identity > Registration >Registration Preferences. I would prefer to keep it to **Invite Only**, if i am the only one using it.
-- Now, goto to **site-name.netlify.app/admin/**, and login with your credentials.
-
-## 📝 Editing content and Adding posts
-
-Once you are in your Netlify CMS, you can navigate to Posts and Pages. Here you will find a list of existing pages and posts.
-
-You can select any existing post or page to start editing or add a **New Post**. Have fun :)
-
-## ⚙ Customing Site details
-
-You can find all the website settings such website Site title, Website URL, Google anlaytics etc,.. in your Netlify CMS `Admin > Settings > General`
-
-## 🌐 Adding Custom domain to netlify website
-
-We have written a short article on [Custom domain with Netlify website](custom-domain)
-
-## 🖥 Install Locally
-
-Use the Gatsby CLI to create a new site, specifying the `gatsby-starter-foundation` starter.
-
+1. Clone the repository:
 ```bash
-gatsby new gatsby-starter-foundation https://github.com/stackrole/gatsby-starter-foundation
+git clone https://github.com/fuzzy31u/yukamiya.me.git
+cd yukamiya.me
 ```
 
-> You need Node and Gatsby-CLI installed, check out Gatsby [Setup Instructions](https://www.gatsbyjs.org/tutorial/part-zero/)
-
-### Start developing
-
-Navigate into your new site’s directory and start it up.
-
-```shell
-cd my-hello-world-starter/
-gatsby develop
+2. Install dependencies:
+```bash
+npm install
 ```
 
-**Open the source code and start editing!**
+3. Start the development server:
+```bash
+npm run develop
+# or
+npm start
+```
 
-Your site is now running at `http://localhost:8000`!
+The site will be available at `http://localhost:8000`
 
-_Note: You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-five/#introducing-graphiql)._
+GraphQL playground: `http://localhost:8000/___graphql`
 
-Open the `gatsby-starter-foundation` directory in your code editor of choice and edit. Save your changes and the browser will update in real time!
+### Local Content Editing with Netlify CMS
 
-You can use Netlify CMS in you local just run `npx netlify-cms-proxy-server` and start run `gatsby develop`
+To use Netlify CMS locally:
 
-## 📁 Folder Structure
+1. In one terminal, start the CMS proxy server:
+```bash
+npx netlify-cms-proxy-server
+```
 
-A quick look at the top-level files and directories you'll see in a Gatsby project.
+2. In another terminal, start Gatsby:
+```bash
+npm run develop
+```
 
-    .
-    ├── node_modules
-    ├── src
-    ├── .gitignore
-    ├── .prettierrc
-    ├── gatsby-browser.js
-    ├── gatsby-config.js
-    ├── gatsby-node.js
-    ├── LICENSE
-    ├── package-lock.json
-    ├── package.json
-    └── README.md
+3. Access the CMS at `http://localhost:8000/admin/`
 
-1.  **`/node_modules`**: This directory contains all of the modules of code that your project depends on (npm packages) are automatically installed.
+### Available Commands
 
-2.  **`/src`**: This directory will contain all of the code related to what you will see on the front-end of your site (what you see in the browser) such as your site header or a page template. `src` is a convention for “source code”.
+- `npm run develop` - Start development server
+- `npm run build` - Build for production
+- `npm run serve` - Serve production build locally
+- `npm run clean` - Clean Gatsby cache and public directory
+- `npm run format` - Format code with Prettier
 
-3.  **`.gitignore`**: This file tells git which files it should not track / not maintain a version history for.
+## Project Structure
 
-4.  **`.prettierrc`**: This is a configuration file for [Prettier](https://prettier.io/). Prettier is a tool to help keep the formatting of your code consistent.
+```
+.
+├── src/
+│   ├── components/     # React components (layout, navigation, etc.)
+│   ├── content/        # Markdown content (pages/ and posts/)
+│   ├── data/           # Structured data (about-content.js)
+│   ├── templates/      # Gatsby page templates
+│   └── util/           # Configuration files (site.json, theme colors, social media)
+├── static/
+│   ├── admin/          # Netlify CMS configuration
+│   └── assets/         # Images and static files
+├── gatsby-config.js    # Gatsby configuration
+├── gatsby-node.js      # Gatsby Node APIs
+└── gatsby-browser.js   # Gatsby browser APIs
+```
 
-5.  **`gatsby-browser.js`**: This file is where Gatsby expects to find any usage of the [Gatsby browser APIs](https://www.gatsbyjs.org/docs/browser-apis/) (if any). These allow customization/extension of default Gatsby settings affecting the browser.
+## Configuration
 
-6.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby site. This is where you can specify information about your site (metadata) like the site title and description, which Gatsby plugins you’d like to include, etc. (Check out the [config docs](https://www.gatsbyjs.org/docs/gatsby-config/) for more detail).
+Site metadata and settings are configured in:
+- `src/util/site.json` - Site title, description, URL, social media handles, Google Analytics
+- `src/util/default-colors.json` - Default theme colors
+- `static/admin/config.yml` - Netlify CMS configuration
 
-7.  **`gatsby-node.js`**: This file is where Gatsby expects to find any usage of the [Gatsby Node APIs](https://www.gatsbyjs.org/docs/node-apis/) (if any). These allow customization/extension of default Gatsby settings affecting pieces of the site build process.
+## Content Management
 
-8.  **`LICENSE`**: Gatsby is licensed under the MIT license.
+### About Page
+The About page uses structured data from `src/data/about-content.js` (not the markdown file). When updating the About page, edit this JavaScript file with proper bilingual titles (ja/en), dates, and URLs.
 
-9.  **`package-lock.json`** (See `package.json` below, first). This is an automatically generated file based on the exact versions of your npm dependencies that were installed for your project. **(You won’t change this file directly).**
+### Blog Posts
+Blog posts are stored in `src/content/posts/` as Markdown files with frontmatter including:
+- `template`: Post template type
+- `title`: Post title
+- `slug`: URL slug
+- `date`: Publication date
 
-10. **`package.json`**: A manifest file for Node.js projects, which includes things like metadata (the project’s name, author, etc). This manifest is how npm knows which packages to install for your project.
+### Static Pages
+Static pages are stored in `src/content/pages/` with similar frontmatter structure.
 
-11. **`README.md`**: A text file containing useful reference information about your project.
+## Deployment
 
-## 🎓 Learning Gatsby
+This site is deployed on Netlify with:
+- **Build Command**: `npm run build`
+- **Publish Directory**: `public`
+- **Node Version**: 14.15.0
+- **Plugin**: @netlify/plugin-gatsby for optimizations
 
-Looking for more guidance? Full documentation for Gatsby lives [on the website](https://www.gatsbyjs.org/). Here are some places to start:
+## Technology Stack
 
-- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://www.gatsbyjs.org/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
+- **Framework**: Gatsby v4
+- **CMS**: Netlify CMS
+- **Styling**: SCSS with Theme UI
+- **Search**: ElasticLunr
+- **Deployment**: Netlify
+- **Analytics**: Google Analytics
 
-- **To dive straight into code samples, head [to our documentation](https://www.gatsbyjs.org/docs/).** In particular, check out the _Guides_, _API Reference_, and _Advanced Tutorials_ sections in the sidebar.
+## License
 
-## 🙏 Thank you
+MIT
 
-We really appreciate you taking time to build your website with our `gatsby-starter-foundation`.
+## Credits
 
-I would love to get your feedback and contributions.
-
-Feel free to ping [@stackrole](stackrole) for help regarding your JAMstack website, our DM's are open. And do not forget to share you website with me 😊
-
-[![Check out Stackrole.com - A Jamstack marketplace](static/assets/twitter-header.jpg)](https://stackrole.com)
-
-[gatsby]: https://gatsbyjs.org
-[netlifycms]: https://www.netlifycms.org
-[stackrole]: https://stackrole.com
-[twitter]: https://twitter.com/stackrole
-[custom-domain]: https://stackrole.com/adding-custom-domain-netlify
+Built with [gatsby-starter-foundation](https://github.com/stackrole/gatsby-starter-foundation)


### PR DESCRIPTION
Replace generic gatsby-starter-foundation template README with site-specific documentation for Yu Kamiya's personal bilingual website.

Closes #40

---
Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites the README to be site-specific for `yukamiya.me`, replacing the starter template with concise docs on features, setup, and operations.
> 
> - Adds live site link and a high-level feature overview (bilingual content, blog, Netlify CMS, theme, search, SEO)
> - Provides development setup: prerequisites, cloning, `npm install`, `npm run develop`, and GraphQL URL
> - Documents local CMS workflow using `npx netlify-cms-proxy-server`
> - Lists available npm scripts for develop/build/serve/clean/format
> - Introduces project structure with a directory tree and key config files (`src/util/site.json`, `static/admin/config.yml`, etc.)
> - Details content locations for About (`src/data/about-content.js`), posts, and static pages
> - Specifies Netlify deployment settings and the technology stack
> - Retains license and credits
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f845ad968c1fd9dab1646a31df9c96d59c7feeea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->