### PR TITLE
feat: add Google Cloud OnBoard Edition badge

### DIFF
--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -10,6 +10,13 @@ export const highlights = [
 export const certifications = [
   {
     title: {
+      ja: 'Google Cloud "Cloud Technical Series - OnBoard Edition"',
+      en: 'Google Cloud "Cloud Technical Series - OnBoard Edition"'
+    },
+    url: 'https://googlecloudapac.accredible.com/29ef7949-e74c-4f17-8137-f8de969c8e4a'
+  },
+  {
+    title: {
       ja: 'GoogleCloud "Generative AI Leader"',
       en: 'GoogleCloud "Generative AI Leader"'
     },


### PR DESCRIPTION
## Summary
- Add Google Cloud "Cloud Technical Series - OnBoard Edition" badge to the certifications section on the About page
- Badge issued by Google Cloud Asia Pacific on Feb 13, 2026 for attending 5+ sessions of the OnBoard Edition live broadcast

Closes #50

## Test plan
- [ ] Verify the About page renders the new badge correctly
- [ ] Verify the badge link opens the Accredible credential page

🤖 Generated with [Claude Code](https://claude.com/claude-code)