### PR TITLE
feat: add Google Cloud OnBoard badge with iframe embed

### DIFF
--- a/src/assets/scss/about.scss
+++ b/src/assets/scss/about.scss
@@ -403,8 +403,18 @@ body.lang-en .bilingual .en { display: inline; }
 // Certifications List
 .certifications-list {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-md);
+  flex-direction: column;
+  gap: var(--spacing-lg);
+
+  .certification-entry {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+
+    &.has-embed {
+      flex-direction: column;
+    }
+  }
 
   .certification-item {
     display: inline-flex;
@@ -427,6 +437,20 @@ body.lang-en .bilingual .en { display: inline; }
     &::before {
       content: '🏅';
       font-size: 1.5rem;
+    }
+  }
+
+  .certification-embed {
+    width: 100%;
+    max-width: 800px;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid var(--color-border);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+
+    iframe {
+      display: block;
+      border: none;
     }
   }
 }

--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -10,6 +10,14 @@ export const highlights = [
 export const certifications = [
   {
     title: {
+      ja: 'Google Cloud "Cloud Technical Series - OnBoard Edition"',
+      en: 'Google Cloud "Cloud Technical Series - OnBoard Edition"'
+    },
+    url: 'https://googlecloudapac.accredible.com/29ef7949-e74c-4f17-8137-f8de969c8e4a',
+    embedUrl: 'https://googlecloudapac.accredible.com/embed/29ef7949-e74c-4f17-8137-f8de969c8e4a'
+  },
+  {
+    title: {
       ja: 'GoogleCloud "Generative AI Leader"',
       en: 'GoogleCloud "Generative AI Leader"'
     },

--- a/src/templates/about-page-redesign.js
+++ b/src/templates/about-page-redesign.js
@@ -36,16 +36,29 @@ const AboutPageRedesign = ({ pageContext }) => {
           </h2>
           <div className="certifications-list">
             {certifications.map((cert, index) => (
-              <a
-                key={index}
-                href={cert.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="certification-item"
-              >
-                <span data-lang="ja">{cert.title.ja}</span>
-                <span data-lang="en">{cert.title.en}</span>
-              </a>
+              <div key={index} className={`certification-entry${cert.embedUrl ? ' has-embed' : ''}`}>
+                <a
+                  href={cert.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="certification-item"
+                >
+                  <span data-lang="ja">{cert.title.ja}</span>
+                  <span data-lang="en">{cert.title.en}</span>
+                </a>
+                {cert.embedUrl && (
+                  <div className="certification-embed">
+                    <iframe
+                      src={cert.embedUrl}
+                      width="100%"
+                      height="500"
+                      frameBorder="0"
+                      allowFullScreen
+                      title={cert.title.en}
+                    />
+                  </div>
+                )}
+              </div>
             ))}
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Add Google Cloud "Cloud Technical Series - OnBoard Edition" certification to the About page
- Embed Accredible credential viewer via iframe for interactive badge display
- Certifications with `embedUrl` field now render an iframe below the badge link
- Certifications without `embedUrl` remain as text links (no behavior change)

Closes #50

## Changed files
- `src/data/about-content.js` - New certification entry with `embedUrl` field
- `src/templates/about-page-redesign.js` - Conditional iframe rendering for embed-enabled certs
- `src/assets/scss/about.scss` - Styles for embedded credential viewer

## Test plan
- [ ] Verify the OnBoard Edition badge appears in the certifications section
- [ ] Verify the iframe loads the Accredible credential page
- [ ] Verify the "Generative AI Leader" badge still renders as a text link only
- [ ] Verify responsive behavior on mobile viewports
- [ ] Verify dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)