### PR TITLE
Add @IT Architect Live 2026 speaking entry

### DIFF
--- a/src/components/TimelineSection.jsx
+++ b/src/components/TimelineSection.jsx
@@ -7,6 +7,7 @@ const TimelineSection = () => {
 
   const filters = [
     { value: 'all', label: { ja: 'すべて', en: 'All' } },
+    { value: '2026', label: { ja: '2026', en: '2026' } },
     { value: '2025', label: { ja: '2025', en: '2025' } },
     { value: '2024', label: { ja: '2024', en: '2024' } },
     { value: '2023', label: { ja: '2023', en: '2023' } },

--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -48,6 +48,16 @@ export const awards = [
 
 export const speaking = [
   {
+    year: '2026',
+    month: '03',
+    title: {
+      ja: 'AIフレンドリーな組織を創る。変革を促す推進室の試行錯誤',
+      en: 'Building an AI-Friendly Organization: Trial and Error in Driving Change'
+    },
+    venue: '@IT Architect Live 2026 冬',
+    url: 'https://members05.live.itmedia.co.jp/library/OTg4Mjg%253D?group=2603_Architect2026w'
+  },
+  {
     year: '2025',
     month: '11',
     title: {


### PR DESCRIPTION
## Summary
- add the new @IT Architect Live 2026 speaking session to the About timeline
- add a 2026 filter tab so the new entry is reachable in the UI
- verify the site builds successfully with Gatsby

## Verification
- XDG_CONFIG_HOME=/tmp npm run build