### PR TITLE
fix: update broken links and correct month data

### DIFF
--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -82,7 +82,7 @@ export const speaking = [
       en: 'App Koshien 2025 Judge'
     },
     venue: 'アプリ甲子園',
-    url: 'https://applikoshien.jp/ai_development'
+    url: 'https://applikoshien.jp/'
   },
   {
     year: '2025',
@@ -123,7 +123,7 @@ export const speaking = [
     },
     venue: 'プロダクトヒストリーカンファレンス',
     role: 'モデレーター',
-    url: 'https://lp-a.youtrust.jp/phc2024/'
+    url: 'https://lp-prohis.youtrust.jp/'
   },
   {
     year: '2024',
@@ -133,7 +133,7 @@ export const speaking = [
       en: 'App Koshien Judge'
     },
     venue: 'アプリ甲子園',
-    url: 'https://applikoshien.jp/2024result'
+    url: 'https://applikoshien.jp/'
   },
   {
     year: '2024',
@@ -163,7 +163,7 @@ export const speaking = [
       en: 'Career Seminar for Girls and Parents'
     },
     venue: '山田進太郎 D&I 財団',
-    url: 'https://www.shinfdn.org/posts/IqchcA6x'
+    url: 'https://web.archive.org/web/2024/https://www.shinfdn.org/posts/IqchcA6x'
   },
   {
     year: '2024',
@@ -193,7 +193,7 @@ export const speaking = [
       en: 'The Value of Diversity at CyberAgent'
     },
     venue: 'GitHub Galaxy Tokyo',
-    url: 'https://resources.github.com/galaxy/tokyo/'
+    url: 'https://web.archive.org/web/2023/https://resources.github.com/galaxy/tokyo/'
   },
   {
     year: '2023',
@@ -282,11 +282,11 @@ export const speaking = [
       en: 'Career Possibilities Through Side Jobs'
     },
     venue: 'BIT VALLEY 2021',
-    url: 'https://2021.bit-valley.jp/program/career/35'
+    url: 'https://web.archive.org/web/2022/https://2021.bit-valley.jp/program/career/35'
   },
   {
     year: '2021',
-    month: '00',
+    month: '02',
     title: {
       ja: 'Women in Tech Meetup Vol.03',
       en: 'Women in Tech Meetup Vol.03'
@@ -296,13 +296,13 @@ export const speaking = [
   },
   {
     year: '2020',
-    month: '00',
+    month: '12',
     title: {
       ja: 'テクノロジー業界における女性のリーダーシップを支援するため',
       en: 'Supporting Women\'s Leadership in Technology Industry'
     },
     venue: 'Wahl & Case',
-    url: 'https://www.wahlandcase.com/jp/webinar/women-leaders-in-the-technology-industry'
+    url: 'https://buildplus.io/jp/webinar/women-leaders-in-the-technology-industry'
   },
   {
     year: '2020',
@@ -316,7 +316,7 @@ export const speaking = [
   },
   {
     year: '2019',
-    month: '00',
+    month: '06',
     title: {
       ja: 'Woman Tech Terrace LT',
       en: 'Woman Tech Terrace LT'
@@ -535,7 +535,7 @@ export const media = [
       en: 'SELECK: Tackling Gender Gap in IT Industry'
     },
     year: '2023',
-    url: 'https://seleck.cc/1608'
+    url: 'https://web.archive.org/web/2023/https://seleck.cc/1608'
   },
   {
     icon: '👩‍🎓',
@@ -589,7 +589,7 @@ export const media = [
       en: 'CyberAgent: Selected as Women Techmakers Ambassador'
     },
     year: '2022',
-    url: 'https://www.cyberagent.co.jp/techinfo/news/detail/id=27684'
+    url: 'https://web.archive.org/web/2023/https://www.cyberagent.co.jp/techinfo/news/detail/id=27684'
   },
   {
     icon: '🎨',
@@ -598,7 +598,7 @@ export const media = [
       en: 'CyberAgent Way: Launch of CAlorful Diversity Project'
     },
     year: '2021',
-    url: 'https://www.cyberagent.co.jp/way/features/list/detail/id=26859'
+    url: 'https://web.archive.org/web/2023/https://www.cyberagent.co.jp/way/features/list/detail/id=26859'
   },
   {
     icon: '📖',


### PR DESCRIPTION
## Summary
- 404/dead リンク 10 件を Archive.org URL または新 URL に更新
- `month: '00'` プレースホルダー 3 件を正しい月に修正（connpass, buildplus.io, wtt.cyberagent.group で確認済み）
- 重複 QA Issue 9 件をクローズ済み

### リンク修正詳細
| 修正内容 | 件数 |
|----------|------|
| 404 → Archive.org URL | 5 件 (shinfdn.org, GitHub Galaxy, CyberAgent x2, SELECK) |
| リダイレクト → 新 URL | 2 件 (YOUTRUST → lp-prohis, Wahl&Case → buildplus.io) |
| 消滅サブページ → メインサイト | 2 件 (applikoshien.jp) |
| リダイレクトループ → Archive.org | 1 件 (BIT VALLEY 2021) |

### month:'00' 修正
| イベント | 修正後 |
|----------|--------|
| Women in Tech Meetup Vol.03 (2021) | `'02'` |
| Wahl & Case webinar (2020) | `'12'` |
| Woman Tech Terrace LT (2019) | `'06'` |

Closes #47, #49, #53, #58

## Test plan
- [x] `npm run build` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)