### PR TITLE
Add AI Banzuke media coverage

### DIFF
--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -477,6 +477,15 @@ export const writing = [
 
 export const media = [
   {
+    icon: "💼",
+    title: {
+      ja: "CyberAgent Way: 全社のAI活用レベルを可視化して底上げする、サイバーエージェント流「AI番付」とは",
+      en: "CyberAgent Way: What Is CyberAgent's AI Banzuke, Visualizing and Raising AI Utilization Levels Across the Company?",
+    },
+    year: "2026",
+    url: "https://www.cyberagent.co.jp/way/list/detail/id=33333",
+  },
+  {
     icon: "📺",
     title: {
       ja: "ビジネス+IT：生成AIを会社の競争力に。サイバーエージェントの全社をあげた取り組み",


### PR DESCRIPTION
## Summary
- add the 2026-05-15 CyberAgent Way AI Banzuke article to the About page media section
- use the canonical article URL: https://www.cyberagent.co.jp/way/list/detail/id=33333
- keep the 2026 media entries in newest-first order

## Verification
- verified source title, og:title, h1, canonical URL, and datetime=2026-05-15
- npm run build
- verified generated /about output includes the new title and id=33333 URL

Closes #74