### PR TITLE
Fix writing year for CyberAgent Developers Blog entry

### DIFF
--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -452,7 +452,7 @@ export const writing = [
       ja: "サイバーエージェントのディベロッパーコミュニティ活性化とDE&Iの取り組み",
       en: "CyberAgent Developer Community and DE&I Initiatives",
     },
-    year: "2025",
+    year: "2024",
     url: "https://developers.cyberagent.co.jp/blog/archives/51796/",
   },
   {


### PR DESCRIPTION
## Summary
- fix the Writing entry year for the CyberAgent Developers Blog article at `/archives/51796/`
- keep the rest of `about-content.js` unchanged
- rebuild and verify the generated `/about` output shows `2024` for that item

## Verification
- `npm run build`
- verified `public/about/index.html` shows `https://developers.cyberagent.co.jp/blog/archives/51796/` with year `2024`
- verified source article title, canonical URL, byline `yukamiya`, and published datetime `2024-12-15T09:00:47+09:00`

Closes #82