### PR TITLE
Resolve stale about page links

### DIFF
--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -102,7 +102,7 @@ export const speaking = [
       en: "App Koshien 2025 Judge",
     },
     venue: "アプリ甲子園",
-    url: "https://applikoshien.jp/",
+    url: "https://techkoshien.jp/",
   },
   {
     year: "2025",
@@ -153,7 +153,7 @@ export const speaking = [
       en: "App Koshien Judge",
     },
     venue: "アプリ甲子園",
-    url: "https://applikoshien.jp/",
+    url: "https://techkoshien.jp/",
   },
   {
     year: "2024",
@@ -163,7 +163,7 @@ export const speaking = [
       en: "Machine Translation Practices for Global Services",
     },
     venue: "CADC 2024",
-    url: "https://cadc.cyberagent.co.jp/2024/sessions/dp-ai-translating/",
+    url: "https://cadc.cyberagent.co.jp/2024/",
   },
   {
     year: "2024",


### PR DESCRIPTION
## Summary
- update App Koshien speaking links from `applikoshien.jp` to the live `techkoshien.jp` domain
- replace the removed CADC 2024 session URL with the live CADC 2024 event page

## Verification
- `curl -I https://techkoshien.jp/` returns HTTP 200
- `curl -I https://cadc.cyberagent.co.jp/2024/` returns HTTP 200
- `npm run build`
- verified generated `public/about/index.html` contains `https://techkoshien.jp/` and `https://cadc.cyberagent.co.jp/2024/`

Fixes #84
Fixes #76