### PR TITLE
feat(about): add Product History Conference 2026 talk

### DIFF
--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -76,6 +76,16 @@ export const awards = [
 export const speaking = [
   {
     year: "2026",
+    month: "06",
+    title: {
+      ja: "開発組織のAI活用レベルを可視化する「エンジニア版AI番付」の取り組み",
+      en: 'Initiatives Behind the "Engineering AI Banzuke" for Visualizing AI Utilization in Development Organizations',
+    },
+    venue: "プロダクトヒストリーカンファレンス 2026",
+    url: "https://lp-prohis.youtrust.jp/",
+  },
+  {
+    year: "2026",
     month: "03",
     title: {
       ja: "AIフレンドリーな組織を創る。変革を促す推進室の試行錯誤",


### PR DESCRIPTION
## Why

The About page was missing a June 2026 speaking engagement that is already publicly listed on the current Product History Conference event page.

## What Changed

Added a new `speaking` entry in `src/data/about-content.js` for Yu Kamiya's June 2026 appearance at `プロダクトヒストリーカンファレンス 2026`, using the current event URL and verified event timing from the source page.

## Verification

Not run. `npm run build` failed in this worktree because `gatsby` is not available on `PATH` (`sh: gatsby: command not found`).
