### PR TITLE
feat(about): add WOMAN×AI speaking event

### DIFF
--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -76,6 +76,17 @@ export const awards = [
 export const speaking = [
   {
     year: "2026",
+    month: "07",
+    title: {
+      ja: "WOMAN×AI「私たちはどうAIと向き合う？」〜AIエキスパートたちに聞く、キャリアが変わる60分〜",
+      en: "WOMAN×AI: How Should We Engage with AI? — 60 Minutes with AI Experts That Can Change Your Career",
+    },
+    venue: "Ms.Engineerオンラインイベント",
+    role: "ゲスト",
+    url: "https://peatix.com/event/5090126",
+  },
+  {
+    year: "2026",
     month: "06",
     title: {
       ja: "開発組織のAI活用レベルを可視化する「エンジニア版AI番付」の取り組み",


### PR DESCRIPTION
## Why

Record Yu Kamiya’s verified July 2026 Ms.Engineer speaking appearance on the About page.

## What Changed

Adds the bilingual WOMAN×AI event entry, guest role, event date, and canonical Peatix link to `src/data/about-content.js`.

Closes #91

## Verification

- `npm run build` completed successfully.
- Generated `public/about/index.html` contains the Japanese and English event titles, venue, guest role, and Peatix URL.
- The Peatix public event payload identifies 神谷優 as a guest for the July 21, 2026 online event.