### PR TITLE
feat(about): add DX&AI Forum speaking event

### DIFF
--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -76,6 +76,17 @@ export const awards = [
 export const speaking = [
   {
     year: "2026",
+    month: "09",
+    title: {
+      ja: "DX&AI Forum 2026 秋 東京",
+      en: "DX&AI Forum 2026 Autumn Tokyo",
+    },
+    venue: "ビジネス+IT",
+    role: "事例講演",
+    url: "https://www.sbbit.jp/eventinfo/dx-ai",
+  },
+  {
+    year: "2026",
     month: "07",
     title: {
       ja: "WOMAN×AI「私たちはどうAIと向き合う？」〜AIエキスパートたちに聞く、キャリアが変わる60分〜",


### PR DESCRIPTION
## Why

Record Yu Kamiya’s verified September 2026 Business+IT case-study presentation on the About page.

## What Changed

Adds the bilingual DX&AI Forum 2026 Autumn Tokyo entry, case-study role, and canonical Business+IT link to `src/data/about-content.js`.

Closes #94

## Verification

- `npm run build` completed successfully.
- Generated `public/about/index.html` contains both bilingual titles, the venue, case-study role, and Business+IT URL.
- The official Business+IT event page lists 神谷優 as a CyberAgent AI-Driven Office Manager under the case-study presentation section for September 18, 2026.