### PR TITLE
fix(review): address Greptile feedback loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ This repository is a bilingual personal website built with Gatsby v4. It uses Ne
 
 - Treat a Greptile score below 5/5 as feedback that must be reviewed, even if the review otherwise says the PR is safe to merge.
 - Verify every Greptile finding against the source and local code. Fix confirmed issues; retain correct canonical data when a finding is disproven, and record the evidence in the PR.
-- After each fix, push the updated PR and re-trigger or wait for a new Greptile review. Repeat until the latest Greptile review reports 5/5 and has no actionable findings.
+- After each fix, push the updated PR and comment `@greptileai` on the PR to force a new review. Repeat until the latest Greptile review reports 5/5 and has no actionable findings.
 - Do not merge until this Greptile gate, required GitHub checks, and the Claude review marker `AUTO_REVIEW_STATUS: pass` have all passed.
 
 ## Deployment Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,15 @@ This repository is a bilingual personal website built with Gatsby v4. It uses Ne
 - When adding URLs (especially to the about page), use a tool to fetch the actual page and verify the correct title — do not rely solely on user notes or memory.
 - All links should have accurate, descriptive titles that match the source content.
 - Check both the title and publication date of linked articles before adding them.
+- Use the source page's canonical URL (or `og:url`) after fetching it. Do not replace a verified canonical URL with a guessed numeric or path-based alternative.
 - The about page is driven by `src/data/about-content.js`. New entries must include bilingual titles (`ja`/`en`), a date, and a URL. Do **not** edit `src/content/pages/about.md` for about page content.
+
+## Automated Review Gate
+
+- Treat a Greptile score below 5/5 as feedback that must be reviewed, even if the review otherwise says the PR is safe to merge.
+- Verify every Greptile finding against the source and local code. Fix confirmed issues; retain correct canonical data when a finding is disproven, and record the evidence in the PR.
+- After each fix, push the updated PR and re-trigger or wait for a new Greptile review. Repeat until the latest Greptile review reports 5/5 and has no actionable findings.
+- Do not merge until this Greptile gate, required GitHub checks, and the Claude review marker `AUTO_REVIEW_STATUS: pass` have all passed.
 
 ## Deployment Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,5 +81,5 @@ This is a personal website built with Gatsby v4 using the gatsby-starter-foundat
 
 - A Greptile score below 5/5 requires review and remediation, even when the review says the change is otherwise safe to merge.
 - Check each Greptile finding against the fetched source and local code. Fix confirmed problems; keep verified canonical data when a finding is incorrect, and document the evidence in the PR.
-- After each fix, push the PR and re-trigger or wait for a new Greptile review. Continue until the latest review reports 5/5 with no actionable findings.
+- After each fix, push the PR and comment `@greptileai` to force a new review. Continue until the latest review reports 5/5 with no actionable findings.
 - Merge only when the Greptile gate, all required GitHub checks, and `AUTO_REVIEW_STATUS: pass` are satisfied.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,5 +73,13 @@ This is a personal website built with Gatsby v4 using the gatsby-starter-foundat
 - Use WebFetch tool to get proper page titles and article names from actual websites
 - Ensure all links have accurate, descriptive titles that match the source content
 - **Important**: Check the details of the title, datetime on the links respectively before adding them to any section
+- Use the canonical URL or `og:url` verified from the fetched source page. Do not replace a verified canonical URL with a guessed numeric or path-based alternative.
 - The about page uses `src/data/about-content.js` for structured data, NOT the markdown file `src/content/pages/about.md`
 - When adding new content to the about page, update `about-content.js` with proper bilingual titles (ja/en), dates, and URLs
+
+## Automated Review Gate
+
+- A Greptile score below 5/5 requires review and remediation, even when the review says the change is otherwise safe to merge.
+- Check each Greptile finding against the fetched source and local code. Fix confirmed problems; keep verified canonical data when a finding is incorrect, and document the evidence in the PR.
+- After each fix, push the PR and re-trigger or wait for a new Greptile review. Continue until the latest review reports 5/5 with no actionable findings.
+- Merge only when the Greptile gate, all required GitHub checks, and `AUTO_REVIEW_STATUS: pass` are satisfied.

--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -538,7 +538,7 @@ export const media = [
   {
     icon: "📺",
     title: {
-      ja: "ビジネス+IT：生成AIを会社の競争力に。サイバーエージェントの全社をあげた取り組み",
+      ja: "ビジネス＋IT：生成AIを会社の競争力に。サイバーエージェントの全社をあげた取り組み",
       en: "Business+IT: Turning Generative AI into a Competitive Advantage Across CyberAgent",
     },
     year: "2026",
@@ -547,7 +547,7 @@ export const media = [
   {
     icon: "📰",
     title: {
-      ja: 'ビジネス+IT：サイバーエージェント流「AI活用組織」の作り方、開発"完全自動化"へのロードマップ',
+      ja: 'ビジネス＋IT：サイバーエージェント流「AI活用組織」の作り方、開発"完全自動化"へのロードマップ',
       en: "Business+IT: CyberAgent's Approach to Building an AI-Driven Organization: Roadmap to Complete Development Automation",
     },
     year: "2026",

--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -81,7 +81,7 @@ export const speaking = [
       ja: "DX&AI Forum 2026 秋 東京",
       en: "DX&AI Forum 2026 Autumn Tokyo",
     },
-    venue: "ビジネス+IT",
+    venue: "ビジネス＋IT",
     role: "事例講演",
     url: "https://www.sbbit.jp/eventinfo/dx-ai",
   },


### PR DESCRIPTION
## Why

PR #95 received a 4/5 Greptile score. The venue and two editorial media prefixes used inconsistent Business+IT spelling; the source confirms the full-width `ビジネス＋IT` form in publisher identity and header imagery. Its URL concern is not valid: the official page identifies `https://www.sbbit.jp/eventinfo/dx-ai` as its canonical and `og:url`, while the inferred numeric path `/eventinfo/88473` returns 404.

## What Changed

- Normalizes all four Business+IT venue/editorial labels in `src/data/about-content.js` to `ビジネス＋IT`.
- Documents canonical URL validation in `AGENTS.md` and `CLAUDE.md`.
- Adds a mandatory fix-and-re-review loop: do not merge until the latest Greptile review is 5/5 with no actionable findings, alongside green checks and `AUTO_REVIEW_STATUS: pass`.

Closes #97

## Verification

- `npm run build` completed successfully after both remediation commits.
- Generated `public/about/index.html` contains four `ビジネス＋IT` labels and no half-width `ビジネス+IT` variant.
- Source metadata confirms `https://www.sbbit.jp/eventinfo/dx-ai` as both canonical URL and `og:url`; `https://www.sbbit.jp/eventinfo/88473` returns HTTP 404.