### PR TITLE
feat(content): add Women in Tech LT 2024 speaking entry

### DIFF
--- a/src/data/about-content.js
+++ b/src/data/about-content.js
@@ -228,6 +228,16 @@ export const speaking = [
     url: "https://forkwell.connpass.com/event/313545/",
   },
   {
+    year: "2024",
+    month: "00",
+    title: {
+      ja: "Women Techmakers Ambassador -Empowering the Next Generation of Global Tech Leaders-",
+      en: "Women Techmakers Ambassador - Empowering the Next Generation of Global Tech Leaders",
+    },
+    venue: "LT event for Women in Tech",
+    url: "https://developers.cyberagent.co.jp/blog/archives/52578/",
+  },
+  {
     year: "2023",
     month: "07",
     title: {


### PR DESCRIPTION
## 概要

自動検出（Auto detect my public activities）で見つかった未掲載の登壇を、About ページの Speaking セクションに追加します。

Closes #100

## 追加内容

`src/data/about-content.js` の `speaking` 配列に 1 件追加しました（`src/content/pages/about.md` は変更していません）。

| 項目 | 値 |
| --- | --- |
| Year | `2024` |
| Month | `00`（不明。下記参照） |
| Title (ja) | Women Techmakers Ambassador -Empowering the Next Generation of Global Tech Leaders- |
| Title (en) | Women Techmakers Ambassador - Empowering the Next Generation of Global Tech Leaders |
| Venue | LT event for Women in Tech |
| URL | https://developers.cyberagent.co.jp/blog/archives/52578/ |

## 一次情報による検証

CyberAgent Developers Blog の開催レポートを取得して確認しました。

- `og:url` = `https://developers.cyberagent.co.jp/blog/archives/52578/`（canonical をそのまま採用）
- `article:published_time` = `2024-12-12T23:00:53+00:00`
- HTTP ステータス: 200

レポート本文の該当箇所:

> 弊社から最後の発表は、Developers Connect室/Tech DE&I Lead 神谷 優による「Women Techmakers Ambassador -Empowering the Next Generation of Global Tech Leaders-」

- 記事の執筆者は **Sena Ishikawa（石川 聖奈）** であり、神谷優は執筆者ではなく **登壇者** です。したがって Writing ではなく Speaking に分類しました。
- イベント: 「LT event for Women in Tech」（GitHub 社・SmartNews 社・ウエディングパーク社・サイバーエージェントの 4 社合同、会場は品川のマイクロソフトオフィス、1 人 5 分の LT で総勢 14 名が登壇）

## month を `00` にした理由

開催日は、確認できたどの一次情報にも記載がありません。

| ソース | 公開日 | 開催日の記載 |
| --- | --- | --- |
| CyberAgent 版レポート（本 PR の URL） | 2024-12-13 | なし |
| ウエディングパーク版レポート `https://engineers.weddingpark.co.jp/report_lightning-talk_2024/` | 2024-12-05 | なし（「先日、…開催いたしました！」のみ） |

2 本とも 2024 年 12 月公開で「先日」と表現しているため **年は 2024 年で確定**ですが、**月は特定できません**。推測で月を埋めず、Issue テンプレート `.github/ISSUE_TEMPLATE/content-addition-speaking.yml` に定義された「不明な場合は 00」の規約に従いました。

`src/components/TimelineSection.jsx:51` は `item.month !== '00' ? ${year}/${month} : year` の実装のため、表示は年のみとなり破綻しません。配列上の位置は、既存の月不明エントリ（2020 年 Waffle Camp、`month: "00"`）と同じく該当年グループの末尾に置いています。

## 検証結果

- `npm run build` 成功
- ビルド成果物を `gatsby serve` で配信し、`/about` を Playwright で確認
  - Speaking タイムラインの「2024」フィルタで新エントリが表示されること
  - 日付表示が `2024`（年のみ）になること
  - リンク先が `https://developers.cyberagent.co.jp/blog/archives/52578/` であること
  - `data-lang="ja"` / `data-lang="en"` の両スパンが出力されていること
- 追加した公開 URL の疎通確認: `https://developers.cyberagent.co.jp/blog/archives/52578/` → 200

> 補足: `/about` の静的 HTML には Speaking の先頭 10 件のみが出力されます（`TimelineSection.jsx:26` の `slice(0, 10)`）。本エントリは 11 件目以降のため、静的 HTML ではなく JS バンドルに含まれ、フィルタ／「もっと見る」操作で描画されます。これは既存の仕様どおりの挙動です。

AUTO_ORCHESTRATED_ISSUE: true

🤖 Generated with [Claude Code](https://claude.com/claude-code)
