### PR TITLE
chore(automation): record empty public-activity sweep for 2026-08-13

### DIFF
--- a/.automation/auto-detect-my-public-activities/memory.md
+++ b/.automation/auto-detect-my-public-activities/memory.md
@@ -28,7 +28,13 @@
 - **`/about` static HTML contains only the first 10 speaking entries** (`TimelineSection.jsx` `slice(0, 10)`); the rest live in the JS bundle and render via the year filter / "もっと見る". Grepping `public/about/index.html` for a newly added entry gives a false negative — verify via the bundle plus a browser filter click.
 - **The `QA Post Deploy` workflow generates false broken-link reports.** It runs on GitHub Actions (US cloud egress) and several Japanese hosts block cloud IPs. Issues #96, #93, #88, #102, #103 were all non-reproducing — every URL returned 200 from a normal connection, with real page content and matching `og:url`. **Always re-verify a link finding yourself, with and without a browser User-Agent, before treating it as real.**
 
+## Cloud environment constraints
+
+- **Some cloud runs have no external egress at all.** On 2026-08-13 the environment's network policy answered `403` to `CONNECT` for every external host — `developers.cyberagent.co.jp`, `zenn.dev`, `cyberagent.co.jp`, `yukamiya.me`, even `google.com` — so both `WebFetch` and `curl` were dead. `WebSearch` still works (it runs server-side, not through the egress proxy), as does GitHub via MCP and npm via the registry bypass. Check `$HTTPS_PROXY/__agentproxy/status` to confirm.
+- Consequence: the sweep can still run, but **source-page validation and link verification cannot**. In that state, never promote a candidate on search-summary evidence alone — record it as `detected` with the egress blocker and leave its validation to a run with egress. Leave `last_checked_at` stale for the author-page sources, and skip `QA Post Deploy` (its link findings would be unverifiable).
+
 ## History
 
 - Detection has found roughly one genuine new item per several weeks. An hourly cadence was tried and produced 11 consecutive empty sweeps before exhausting the session search budget; weekly matches the real rate.
 - Last shipped change: PR #101 (merged 2026-08-09) added the Women in Tech LT 2024 speaking entry. Verified live in production.
+- 2026-08-13: empty sweep (18 queries, 0 new). Every hit was already in `about-content.js` or a known collision.

--- a/.automation/auto-detect-my-public-activities/state.json
+++ b/.automation/auto-detect-my-public-activities/state.json
@@ -8,22 +8,22 @@
       "last_checked_at": "2026-07-23T11:00:45Z"
     },
     "サイバーエージェント 神谷優": {
-      "last_checked_at": "2026-08-10T15:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "神谷優 登壇 記事 インタビュー 受賞": {
       "last_checked_at": "2026-05-23T05:26:17Z"
     },
     "神谷優 登壇": {
-      "last_checked_at": "2026-08-10T15:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "神谷優 記事": {
-      "last_checked_at": "2026-08-10T15:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "神谷優 インタビュー": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "神谷優 受賞": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "神谷優 インタビュー OR 神谷優 受賞": {
       "last_checked_at": "2026-06-21T00:11:09Z"
@@ -38,40 +38,40 @@
       "last_checked_at": "2026-05-23T05:26:17Z"
     },
     "fuzzy31u": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "yukamiya": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "Yu Kamiya fuzzy31u": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "\"Yu Kamiya\" fuzzy31u": {
       "last_checked_at": "2026-05-31T00:03:28Z"
     },
     "神谷優 fuzzy31u": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "\"神谷優\" fuzzy31u OR yukamiya": {
       "last_checked_at": "2026-06-21T00:11:09Z"
     },
     "神谷優 yukamiya": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "site:developers.cyberagent.co.jp/blog fuzzy31u": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "site:developers.cyberagent.co.jp/blog yukamiya": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "site:developers.cyberagent.co.jp/blog 神谷優": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "site:developers.cyberagent.co.jp/blog \"Yu Kamiya\" OR developers.cyberagent.co.jp/blog/archives/63720": {
       "last_checked_at": "2026-07-26T13:13:15Z"
     },
     "site:developers.cyberagent.co.jp/blog \"Yu Kamiya\"": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "fuzzy31u CyberAgent": {
       "last_checked_at": "2026-07-12T00:43:03Z"
@@ -80,10 +80,10 @@
       "last_checked_at": "2026-07-12T00:43:03Z"
     },
     "developers.cyberagent.co.jp/blog/archives/63720": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "site:developers.cyberagent.co.jp/blog/archives/ CyberAgent Developers Blog 神谷優": {
-      "last_checked_at": "2026-08-10T14:37:00Z"
+      "last_checked_at": "2026-08-13T09:13:56Z"
     },
     "\"神谷優\" \"2026/05\" OR \"2026-05\"": {
       "last_checked_at": "2026-05-31T00:03:28Z"
@@ -159,6 +159,12 @@
     },
     "\"CA BASE NEXT 2022\" サイバーエージェント若手流を轟かせる開発チームの裏側 マネジメント編": {
       "last_checked_at": "2026-08-10T05:37:00Z"
+    },
+    "\"神谷優\" サイバーエージェント 2026年8月": {
+      "last_checked_at": "2026-08-13T09:13:56Z"
+    },
+    "\"神谷優\" AIドリブン推進室 登壇 OR 講演 OR イベント": {
+      "last_checked_at": "2026-08-13T09:13:56Z"
     }
   },
   "activities": {
@@ -358,20 +364,20 @@
     }
   },
   "runs": {
-    "last_checked_at": "2026-08-13T08:57:27Z",
-    "last_status": "merged",
-    "last_blocker": null,
-    "last_result": "State migrated from the local machine into this repository so the weekly cloud routine can read and write it. The prior 'blocked' status was a local-session WebSearch budget artifact and does not apply to cloud runs, which start with a fresh budget.",
+    "last_checked_at": "2026-08-13T09:13:56Z",
+    "last_status": "no_new_activity",
+    "last_blocker": "Partial coverage: all 18 WebSearch queries ran and surfaced nothing new, but the two authoritative author-page fetches could NOT run. This cloud environment's network egress policy denies every external host (CONNECT returns 403 for developers.cyberagent.co.jp, zenn.dev, cyberagent.co.jp, forbesjapan.com, yukamiya.me and google.com alike), so WebFetch and curl are both unusable. Source-page validation and link verification were therefore impossible this run; their last_checked_at stamps were deliberately left stale. No candidate needed validation, so this gap did not suppress any finding — but a future run in the same environment could not validate one if it appeared.",
+    "last_result": "Weekly sweep found no new public activity. Every hit across the 18 queries is already represented in src/data/about-content.js (forbesjapan/74649, way id=28637, techinfo id=27684, codezine/16896, archives 50516 / 51796 / 52578 / 63720, SKO radio, Speaker Deck profile) or is a known name collision. The `site:...blog yukamiya` summary again misattributed archives/39730 (CA BASE NEXT 2022) to yukamiya — already in rejected_candidates, skipped. No issue, no content change; state-only commit.",
     "last_deploy_verification": {
       "url": "https://yukamiya.me/about/",
       "verified_at": "2026-08-10T04:37:30Z",
       "result": "PR #101 entry is live in production: 2024 filter renders 'Women Techmakers Ambassador - Empowering the Next Generation of Global Tech Leaders' with year-only date and href https://developers.cyberagent.co.jp/blog/archives/52578/. 0 console errors/warnings."
     },
     "qa_post_deploy": {
-      "run_id": 31315858254,
-      "conclusion": "success",
-      "source_pr_url": "https://github.com/fuzzy31u/yukamiya.me/pull/101",
-      "note": "Opened issues #102/#103; both re-verified as environment false positives and closed. Link checking from GitHub Actions US egress is unreliable for these Japanese hosts."
+      "run_id": null,
+      "conclusion": "not_triggered",
+      "source_pr_url": null,
+      "note": "Deliberately not triggered: no content change shipped this run, and with all external egress blocked this session could not re-verify any link finding the workflow reported. Triggering it would have produced unresolvable false positives."
     }
   },
   "rejected_candidates": {


### PR DESCRIPTION
State-only update from the weekly "Auto detect my public activities" run. No site content changed.

## Result

18 search queries ran and surfaced **no new public activity**. Every hit was already represented in `src/data/about-content.js` — `forbesjapan/74649`, `way id=28637`, `techinfo id=27684`, `codezine/16896`, Developers Blog `50516` / `51796` / `52578` / `63720`, the SKO Radio episodes, the Speaker Deck profile — or is a known name collision (神谷優太 the footballer, 神谷浩史 the voice actor, the Kanagawa University acoustics student).

The `site:developers.cyberagent.co.jp/blog yukamiya` summary again misattributed `archives/39730` (CA BASE NEXT 2022, written by `syuta`) to yukamiya. That is already in `rejected_candidates`, so it was skipped without re-investigation.

No issue was opened and no content change was made — most weeks legitimately find nothing.

## Coverage gap (recorded, not papered over)

This environment's network egress policy denied **every** external host — `CONNECT` returned 403 for `developers.cyberagent.co.jp`, `zenn.dev`, `cyberagent.co.jp`, `forbesjapan.com`, `yukamiya.me` and `google.com` alike — so both `WebFetch` and `curl` were unusable. `WebSearch` still works because it runs server-side.

Consequences, all reflected in `state.json`:

- The two authoritative author-page fetches could not run, so their `last_checked_at` stamps were **left stale** rather than falsely refreshed.
- Source-page validation and link verification were impossible. No candidate needed validating this run, so nothing was suppressed — but `memory.md` now documents the no-egress mode so a future run knows not to promote a candidate on search-summary evidence alone.
- `QA Post Deploy` was deliberately not triggered: no content shipped, and its link findings could not have been re-verified from here.

## Files

- `.automation/auto-detect-my-public-activities/state.json` — stamped the 18 queries that actually ran, recorded the run result and the egress blocker.
- `.automation/auto-detect-my-public-activities/memory.md` — added the cloud no-egress constraint and this run's history line.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JA5xFE3y62ESeLhrHjh1Lr)_